### PR TITLE
Remove AppLayout sidebar and add finish confirmation to BRT-A test

### DIFF
--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import AppLayout from '@/layouts/AppLayout.vue';
+import AppHeaderLayout from '@/layouts/app/AppHeaderLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
@@ -22,6 +22,7 @@ interface Question {
 const breadcrumbs: BreadcrumbItem[] = [
   { title: 'Tests', href: '/tests' },
 ];
+const testName = 'BRT-A';
 const questions = ref<Question[]>([
   { text: "619020 – 541600 = ?", answers: ["77420"] },
   { text: "619020 = 174309 + ?", answers: ["444711"] },
@@ -147,10 +148,6 @@ const handleNextClick = () => {
     if (currentQuestionIndex.value < questions.value.length - 1) {
       currentQuestionIndex.value++;
       nextButtonClickCount.value = 0;
-    } else {
-      // Complete test: move index past last question
-      currentQuestionIndex.value = questions.value.length;
-      nextButtonClickCount.value = 0;
     }
   }
 };
@@ -171,6 +168,23 @@ const handlePrevClick = () => {
     currentQuestionIndex.value--;
     nextButtonClickCount.value = 0;
   }
+};
+
+const finishTest = () => {
+  if (!window.confirm('Sind Sie sicher, den Test zu beenden? Es gibt kein Zurück.')) return;
+  const now = Date.now();
+  if (
+    currentQuestionIndex.value >= 0 &&
+    currentQuestionIndex.value < questions.value.length &&
+    questionStartTimestamps.value[currentQuestionIndex.value]
+  ) {
+    questionTimes.value[currentQuestionIndex.value] += Math.round(
+      (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
+    );
+    questionStartTimestamps.value[currentQuestionIndex.value] = null;
+  }
+  currentQuestionIndex.value = questions.value.length;
+  nextButtonClickCount.value = 0;
 };
 
 // Per-question timer starter
@@ -243,8 +257,9 @@ function isCorrectAnswer(userAnswer: string | undefined, validAnswers: string[])
 <template>
 
   <Head title="Tests" />
-  <AppLayout :breadcrumbs="breadcrumbs">
-    <div class="flex flex-1 min-h-[600px] gap-4 rounded-xl p-4 bg-muted/20">
+  <AppHeaderLayout :breadcrumbs="breadcrumbs">
+    <div class="relative flex flex-1 min-h-[600px] gap-4 rounded-xl p-4 bg-muted/20">
+      <div class="absolute top-2 right-4 font-bold">{{ testName }}</div>
       <!-- Sidebar Navigation: Only visible during the test -->
       <aside v-if="showTest" class="w-64 flex-shrink-0 flex flex-col items-start space-y-2  py-4 h-fit sticky top-8">
         <h3 class="font-bold mb-2 text-sm text-muted-foreground pl-4">Fragen</h3>
@@ -302,12 +317,15 @@ function isCorrectAnswer(userAnswer: string | undefined, validAnswers: string[])
               <Button @click="handlePrevClick" :disabled="currentQuestionIndex === 0" variant="outline">
                 Zurück
               </Button>
-              <Button @click="handleNextClick">
+              <Button v-if="currentQuestionIndex < questions.length - 1" @click="handleNextClick">
                 {{ nextButtonText }}
+              </Button>
+              <Button v-else @click="finishTest" variant="destructive">
+                Test beenden
               </Button>
             </div>
           </div>
-          <p v-if="nextButtonClickCount === 1" class="text-sm text-muted-foreground mt-2">
+          <p v-if="currentQuestionIndex < questions.length - 1 && nextButtonClickCount === 1" class="text-sm text-muted-foreground mt-2">
             Klicken Sie erneut auf "Weiter (Bestätigen)", um fortzufahren.
           </p>
         </div>
@@ -388,5 +406,5 @@ function isCorrectAnswer(userAnswer: string | undefined, validAnswers: string[])
         </div>
       </div>
     </div>
-  </AppLayout>
+  </AppHeaderLayout>
 </template>


### PR DESCRIPTION
## Summary
- Switch BRT-A to header layout to hide global sidebar and display test name in the corner
- Restore in-test question navigation sidebar
- Add confirmation-based "Test beenden" button on final question

## Testing
- `npm run lint` *(fails: sh: 1: eslint: not found)*
- `npm run format:check` *(fails: sh: 1: prettier: not found)*
- `phpunit` *(fails: command not found: phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_689b2ae2dfa48329ae1b160f30755480