### PR TITLE
feat: preload demographics from profile

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -44,7 +44,7 @@ class HandleInertiaRequests extends Middleware
             'name' => config('app.name'),
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
-                'user' => $request->user(),
+                'user' => $request->user()?->load('participantProfile'),
             ],
             'ziggy' => [
                 ...(new Ziggy)->toArray(),


### PR DESCRIPTION
## Summary
- show authenticated user's name on FPI-R test page without AppLayout wrapper
- add finish test button that confirms before emitting completion
- preload sex and age from the participant profile instead of manual entry
- move finish button to final question page instead of results

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/EPT/node_modules/eslint-config-prettier/index.js' imported from /workspace/EPT/eslint.config.js)*
- `npm run format:check` *(fails: Cannot find package '/workspace/EPT/node_modules/prettier-plugin-organize-imports/' imported from /workspace/EPT/noop.js)*

------
https://chatgpt.com/codex/tasks/task_e_689c4401d6ec8329a8db018dd41210a4