### PR TITLE
Fix exam dialog and fullscreen exit behavior

### DIFF
--- a/resources/js/components/ui/dialog/DialogContent.vue
+++ b/resources/js/components/ui/dialog/DialogContent.vue
@@ -38,12 +38,14 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     >
       <slot />
 
-      <DialogClose
-        class="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-      >
-        <X />
-        <span class="sr-only">Close</span>
-      </DialogClose>
+      <slot name="top-right">
+        <DialogClose
+          class="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+        >
+          <X />
+          <span class="sr-only">Close</span>
+        </DialogClose>
+      </slot>
     </DialogContent>
   </DialogPortal>
 </template>

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { Head, router } from '@inertiajs/vue3'
+import { Head, router, usePage } from '@inertiajs/vue3'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -45,6 +45,8 @@ const props = defineProps<{
 const activeTestComponent = ref(null)
 const isTestDialogOpen = ref(false)
 const activeStepId = ref<number | null>(null)
+const page = usePage()
+const userName = computed(() => page.props.auth?.user?.name)
 
 const testComponents = {
   'BRT-A': BRTA,
@@ -100,8 +102,12 @@ function requestFullscreen() {
 
 function handleFullscreenChange() {
   if (!document.fullscreenElement) {
-    alert('You have exited full-screen mode. The test will now end.')
-    completeTest()
+    const confirmExit = confirm('You have exited full-screen mode. The test will now end. Do you want to continue?')
+    if (confirmExit) {
+      completeTest()
+    } else {
+      requestFullscreen()
+    }
   }
 }
 
@@ -187,6 +193,9 @@ onUnmounted(() => {
                     </DialogTrigger>
                     <DialogContent
                       class="inset-0 top-0 left-0 w-screen h-screen max-w-none sm:max-w-none translate-x-0 translate-y-0 rounded-none border-none p-0 bg-white dark:bg-gray-900 text-black dark:text-white overflow-auto">
+                      <template #top-right>
+                        <div class="absolute top-4 right-4 font-semibold">{{ userName }}</div>
+                      </template>
                       <component :is="activeTestComponent" class="w-full h-full" @complete="completeTest" />
                     </DialogContent>
                   </Dialog>


### PR DESCRIPTION
## Summary
- Replace dialog close button with participant name during tests
- Prompt for confirmation when exiting fullscreen, allowing cancel

## Testing
- `npm run lint` (fails: Cannot find package 'eslint-config-prettier')
- `./vendor/bin/phpunit` (fails: No such file or directory)
- `composer install` (fails: ext-ldap missing)


------
https://chatgpt.com/codex/tasks/task_e_689d91119d5883298afb7a09390f4542