### PR TITLE
Handle fullscreen exit and add broken test state

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -136,4 +136,19 @@ class ParticipantController extends Controller
 
     return back(303);
   }
+
+  public function breakStep(Request $request)
+  {
+    $user = Auth::user();
+    $examStepStatus = ExamStepStatus::where('participant_id', $user->id)
+      ->where('exam_step_id', $request->input('exam_step_id'))
+      ->firstOrFail();
+
+    $examStepStatus->update([
+      'status' => 'broken',
+      'completed_at' => now(),
+    ]);
+
+    return back(303);
+  }
 }

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -177,10 +177,14 @@ const handlePrevClick = () => {
 };
 
 const finishTest = () => {
+  window.dispatchEvent(new Event('start-finish'))
   const confirmed = window.confirm(
     'Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.'
-  );
-  if (!confirmed) return;
+  )
+  if (!confirmed) {
+    window.dispatchEvent(new Event('cancel-finish'))
+    return
+  }
   const now = Date.now();
   if (
     currentQuestionIndex.value >= 0 &&
@@ -194,7 +198,7 @@ const finishTest = () => {
   }
   currentQuestionIndex.value = questions.value.length;
   nextButtonClickCount.value = 0;
-  emit('complete');
+  emit('complete')
 };
 
 // Per-question timer starter

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -3,6 +3,14 @@ import { Head, usePage } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
 
 const page = usePage<{ auth: { user: { name: string } } }>();
 const userName = computed(() => page.props.auth?.user?.name ?? '');
@@ -49,6 +57,7 @@ const answerInput = ref<InstanceType<typeof Input> | null>(null);
 const questionTimes = ref<number[]>(Array(questions.value.length).fill(0));
 const questionStartTimestamps = ref<(number | null)[]>(Array(questions.value.length).fill(null));
 const startTime = ref<number | null>(null);
+const endConfirmOpen = ref(false);
 
 function formatQuestionMark(text: string): string {
   if (text.endsWith('?')) {
@@ -177,14 +186,11 @@ const handlePrevClick = () => {
 };
 
 const finishTest = () => {
-  window.dispatchEvent(new Event('start-finish'))
-  const confirmed = window.confirm(
-    'Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.'
-  )
-  if (!confirmed) {
-    window.dispatchEvent(new Event('cancel-finish'))
-    return
-  }
+  window.dispatchEvent(new Event('start-finish'));
+  endConfirmOpen.value = true;
+};
+
+const confirmEnd = () => {
   const now = Date.now();
   if (
     currentQuestionIndex.value >= 0 &&
@@ -198,7 +204,13 @@ const finishTest = () => {
   }
   currentQuestionIndex.value = questions.value.length;
   nextButtonClickCount.value = 0;
-  emit('complete')
+  endConfirmOpen.value = false;
+  emit('complete');
+};
+
+const cancelEnd = () => {
+  window.dispatchEvent(new Event('cancel-finish'));
+  endConfirmOpen.value = false;
 };
 
 // Per-question timer starter
@@ -423,5 +435,19 @@ function isCorrectAnswer(userAnswer: string | undefined, validAnswers: string[])
         </div>
       </div>
     </div>
+    <Dialog v-model:open="endConfirmOpen">
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Test beenden</DialogTitle>
+          <DialogDescription>
+            Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter class="gap-2">
+          <Button variant="secondary" @click="cancelEnd">Abbrechen</Button>
+          <Button variant="destructive" @click="confirmEnd">Ja</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   </div>
 </template>

--- a/resources/js/pages/BRT-B.vue
+++ b/resources/js/pages/BRT-B.vue
@@ -177,10 +177,14 @@ const handlePrevClick = () => {
 };
 
 const finishTest = () => {
+  window.dispatchEvent(new Event('start-finish'))
   const confirmed = window.confirm(
     'Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.'
-  );
-  if (!confirmed) return;
+  )
+  if (!confirmed) {
+    window.dispatchEvent(new Event('cancel-finish'))
+    return
+  }
   const now = Date.now();
   if (
     currentQuestionIndex.value >= 0 &&
@@ -194,7 +198,7 @@ const finishTest = () => {
   }
   currentQuestionIndex.value = questions.value.length;
   nextButtonClickCount.value = 0;
-  emit('complete');
+  emit('complete')
 };
 
 // Per-question timer starter

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -6,6 +6,10 @@ import {
   Dialog,
   DialogContent,
   DialogTrigger,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
 } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
@@ -119,6 +123,7 @@ function breakTest() {
 
 // --- Fullscreen and Anti-Cheating ---
 const finishing = ref(false)
+const fullscreenWarningOpen = ref(false)
 
 function requestFullscreen() {
   const elem = document.documentElement
@@ -128,15 +133,18 @@ function requestFullscreen() {
 function handleFullscreenChange() {
   if (!document.fullscreenElement) {
     if (finishing.value) return
-    const confirmExit = confirm(
-      'Sie haben den Vollbildmodus verlassen. Der Test wird jetzt beendet. Klicken Sie auf "OK", um den Test zu beenden, oder auf "Abbrechen", um fortzufahren.'
-    )
-    if (confirmExit) {
-      breakTest()
-    } else {
-      requestFullscreen()
-    }
+    fullscreenWarningOpen.value = true
   }
+}
+
+function confirmFullscreenExit() {
+  fullscreenWarningOpen.value = false
+  breakTest()
+}
+
+function cancelFullscreenExit() {
+  fullscreenWarningOpen.value = false
+  requestFullscreen()
 }
 
 function beginFinish() {
@@ -250,5 +258,19 @@ onUnmounted(() => {
       </div>
 
     </div>
+    <Dialog :open="fullscreenWarningOpen">
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Vollbildmodus verlassen</DialogTitle>
+          <DialogDescription>
+            Sie haben den Vollbildmodus verlassen. Der Test wird jetzt beendet. Klicken Sie auf „Ja“, um den Test zu beenden, oder auf „Abbrechen“, um fortzufahren.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter class="gap-2">
+          <Button variant="secondary" @click="cancelFullscreenExit">Abbrechen</Button>
+          <Button variant="destructive" @click="confirmFullscreenExit">Ja</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   </div>
 </template>

--- a/resources/js/pages/FPI-R.vue
+++ b/resources/js/pages/FPI-R.vue
@@ -12,6 +12,14 @@ import { norms_female_25_44 } from '@/pages/Scores/FPI/norms_female_25_44';
 import { norms_female_45_59 } from '@/pages/Scores/FPI/norms_female_45_59';
 import { norms_female_60up } from '@/pages/Scores/FPI/norms_female_60up';
 import FPIResult from '@/pages/Scores/FPI/FPIResult.vue';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
 
 const page = usePage<{
   auth: {
@@ -74,6 +82,7 @@ const blockIndex = ref(0);
 const answers = ref<Record<number, 'stimmt' | 'stimmtNicht' | null>>({});
 const missedQuestions = ref<number[]>([]);
 const finished = ref(false);
+const endConfirmOpen = ref(false);
 const totalQuestions = FPI_QUESTIONS.length;
 const currentFrom = computed(() => blockIndex.value * QUESTIONS_PER_BLOCK + 1);
 const currentTo = computed(() => Math.min((blockIndex.value + 1) * QUESTIONS_PER_BLOCK, totalQuestions));
@@ -208,15 +217,18 @@ function restart() {
 
 function finishTest() {
   window.dispatchEvent(new Event('start-finish'))
-  const confirmed = window.confirm(
-    'Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.'
-  )
-  if (!confirmed) {
-    window.dispatchEvent(new Event('cancel-finish'))
-    return
-  }
+  endConfirmOpen.value = true
+}
+
+function confirmEnd() {
   handleNextBlock()
+  endConfirmOpen.value = false
   emit('complete')
+}
+
+function cancelEnd() {
+  window.dispatchEvent(new Event('cancel-finish'))
+  endConfirmOpen.value = false
 }
 
 function getStanineKey(idx: number) {
@@ -411,6 +423,20 @@ const staninePoints = computed(() => {
 
       </div>
     </div>
-
+    <Dialog v-model:open="endConfirmOpen">
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Test beenden</DialogTitle>
+          <DialogDescription>
+            Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter class="gap-2">
+          <Button variant="secondary" @click="cancelEnd">Abbrechen</Button>
+          <Button variant="destructive" @click="confirmEnd">Ja</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   </div>
 </template>
+

--- a/resources/js/pages/FPI-R.vue
+++ b/resources/js/pages/FPI-R.vue
@@ -207,12 +207,16 @@ function restart() {
 }
 
 function finishTest() {
+  window.dispatchEvent(new Event('start-finish'))
   const confirmed = window.confirm(
     'Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.'
-  );
-  if (!confirmed) return;
-  handleNextBlock();
-  emit('complete');
+  )
+  if (!confirmed) {
+    window.dispatchEvent(new Event('cancel-finish'))
+    return
+  }
+  handleNextBlock()
+  emit('complete')
 }
 
 function getStanineKey(idx: number) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::get('/no-exam', [ParticipantController::class, 'noExam'])->name('participant.no-exam');
     Route::post('/my-exam/start-step', [ParticipantController::class, 'startStep'])->name('my-exam.start-step');
     Route::post('/my-exam/complete-step', [ParticipantController::class, 'completeStep'])->name('my-exam.complete-step');
+    Route::post('/my-exam/break-step', [ParticipantController::class, 'breakStep'])->name('my-exam.break-step');
 
     // Exam management (teacher/admin only, add middleware if needed)
     Route::post('/exam-step-status/{status}/add-time', [ExamStepStatusController::class, 'addTime'])->name('exam-step-status.add-time');


### PR DESCRIPTION
## Summary
- ignore fullscreen exit when ending test intentionally
- warn in German and mark test broken on unexpected fullscreen exit
- allow backend to record broken exam steps

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `composer install` *(fails: ext-ldap missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d967215e483298cd45e526cb97c6e