### PR TITLE
Scroll to top after LMT pages

### DIFF
--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -124,6 +124,10 @@ function startTest() {
   })
 }
 
+function scrollToTop() {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
 function handleNextPage() {
   stopTimingCurrentPage()
 
@@ -133,6 +137,7 @@ function handleNextPage() {
   } else {
     completeTest()
   }
+  scrollToTop()
 }
 
 function handlePrevPage() {

--- a/resources/js/pages/LMT2.vue
+++ b/resources/js/pages/LMT2.vue
@@ -38,6 +38,10 @@ function startTest() {
   startTime.value = null
 }
 
+function scrollToTop() {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
 function handlePrevClick() {
   stopTiming(currentQuestionIndex.value)
   if (currentQuestionIndex.value > 0) {
@@ -53,6 +57,7 @@ function handleNextClick() {
   } else {
     currentQuestionIndex.value = questions.value.length
   }
+  scrollToTop()
 }
 
 function stopTiming(index: number) {
@@ -76,6 +81,7 @@ function selectAnswerAndAdvance(optionIndex: number) {
   } else {
     currentQuestionIndex.value = questions.value.length
   }
+  scrollToTop()
 }
 
 watch(currentQuestionIndex, async (newIndex, oldIndex) => {


### PR DESCRIPTION
## Summary
- Scroll to top when moving to next page in multi-question LMT
- Scroll to top when advancing questions in single-question LMT2 view

## Testing
- `npx eslint resources/js/pages/LMT.vue resources/js/pages/LMT2.vue --fix` *(fails: Cannot find package 'eslint-config-prettier')*
- `npx prettier resources/js/pages/LMT.vue resources/js/pages/LMT2.vue --check` *(fails: Cannot find package 'prettier-plugin-organize-imports')*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install --ignore-platform-req=ext-ldap` *(fails: needs GitHub credentials for private packages)*

------
https://chatgpt.com/codex/tasks/task_e_689deddde9348329af8fef5d41f670ab