### PR TITLE
Add real-time dashboard user updates

### DIFF
--- a/app/Http/Controllers/TeacherController.php
+++ b/app/Http/Controllers/TeacherController.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use App\Models\TestAssignment;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class TeacherController extends Controller
 {
@@ -24,11 +25,18 @@ class TeacherController extends Controller
       ->orderBy('created_at', 'desc')
       ->get();
 
-    // New: Fetch users created in the last 6 hours in the same city
+    // New: Fetch users who have logged in within the last 6 hours in the same city
+    $recentUserIds = DB::table('sessions')
+      ->select('user_id')
+      ->whereNotNull('user_id')
+      ->where('last_activity', '>=', Carbon::now()->subHours(6)->getTimestamp())
+      ->distinct()
+      ->pluck('user_id');
+
     $recentUsers = User::where('role', 'participant')
       ->where('city_id', $cityId)
-      ->where('created_at', '>=', Carbon::now()->subHours(6))
-      ->orderBy('created_at', 'desc')
+      ->whereIn('id', $recentUserIds)
+      ->orderBy('id', 'desc')
       ->get();
 
     // New: Fetch all exams
@@ -55,10 +63,17 @@ class TeacherController extends Controller
       ->orderBy('created_at', 'desc')
       ->get();
 
+    $recentUserIds = DB::table('sessions')
+      ->select('user_id')
+      ->whereNotNull('user_id')
+      ->where('last_activity', '>=', Carbon::now()->subHours(6)->getTimestamp())
+      ->distinct()
+      ->pluck('user_id');
+
     $recentUsers = User::where('role', 'participant')
       ->where('city_id', $cityId)
-      ->where('created_at', '>=', Carbon::now()->subHours(6))
-      ->orderBy('created_at', 'desc')
+      ->whereIn('id', $recentUserIds)
+      ->orderBy('id', 'desc')
       ->get();
 
     return response()->json([

--- a/app/Http/Controllers/TeacherController.php
+++ b/app/Http/Controllers/TeacherController.php
@@ -44,6 +44,29 @@ class TeacherController extends Controller
     ]);
   }
 
+  public function dashboardData()
+  {
+    $teacher = Auth::user();
+    $cityId = $teacher->city_id;
+
+    $participants = User::with(['city', 'testAssignments.test'])
+      ->where('role', 'participant')
+      ->where('city_id', $cityId)
+      ->orderBy('created_at', 'desc')
+      ->get();
+
+    $recentUsers = User::where('role', 'participant')
+      ->where('city_id', $cityId)
+      ->where('created_at', '>=', Carbon::now()->subHours(6))
+      ->orderBy('created_at', 'desc')
+      ->get();
+
+    return response()->json([
+      'participants' => $participants,
+      'recentUsers' => $recentUsers,
+    ]);
+  }
+
   // 2. Assign Tests
   public function assignTests(Request $request)
   {

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -13,8 +13,8 @@ const props = defineProps<{
   tests: any[];
 }>();
 
-const participants = ref(props.participants);
-const recentUsers = ref(props.recentUsers);
+const participants = ref(props.participants || []);
+const recentUsers = ref(props.recentUsers || []);
 const activeExam = ref(null);
 let polling: any = null;
 
@@ -30,8 +30,8 @@ const fetchActiveExam = async () => {
 const fetchDashboardUsers = async () => {
   try {
     const response = await axios.get(route('api.dashboard-data'));
-    participants.value = response.data.participants;
-    recentUsers.value = response.data.recentUsers;
+    participants.value = response.data.participants || [];
+    recentUsers.value = response.data.recentUsers || [];
   } catch (error) {
     console.error("Error fetching dashboard data:", error);
   }
@@ -120,7 +120,7 @@ function toggleRow(id: number, idx: number) {
     selectedIdx.value = idx;
   }
 }
-const availableRecentUsers = computed(() => recentUsers.value.filter((u) => !stagedUserIds.value.includes(u.id)));
+const availableRecentUsers = computed(() => (recentUsers.value || []).filter((u) => !stagedUserIds.value.includes(u.id)));
 
 function singleRowSelect(idx: number, id: number) {
   selectedIdx.value = idx;

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/exams/store-with-participants', [ExamController::class, 'storeWithParticipants'])->name('exams.storeWithParticipants');
     Route::put('/exams/{exam}/steps', [ExamController::class, 'updateSteps'])->name('exams.updateSteps');
     Route::get('/api/active-exam', [ExamController::class, 'getActiveExam'])->name('api.active-exam');
+    Route::get('/api/dashboard-data', [TeacherController::class, 'dashboardData'])->name('api.dashboard-data');
 });
 
 Route::get('/login', function () {


### PR DESCRIPTION
## Summary
- poll new participants and recent users for dashboard
- expose `/api/dashboard-data` endpoint to retrieve latest users
- refresh dashboard lists without page reload

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `composer test` *(fails: vendor autoload.php missing; composer install failed due to missing ext-ldap and 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dee2095c08329999b10246121a329