### PR TITLE
Add uncompleted exam step status for early exits

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -145,7 +145,7 @@ class ParticipantController extends Controller
       ->firstOrFail();
 
     $examStepStatus->update([
-      'status' => 'broken',
+      'status' => 'uncompleted',
       'completed_at' => now(),
     ]);
 

--- a/database/migrations/2025_08_01_081640_create_exam_step_statuses_table.php
+++ b/database/migrations/2025_08_01_081640_create_exam_step_statuses_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
       $table->foreignId('exam_id')->constrained('exams')->cascadeOnDelete();
       $table->foreignId('participant_id')->constrained('users')->cascadeOnDelete();
       $table->foreignId('exam_step_id')->constrained('exam_steps')->cascadeOnDelete();
-      $table->enum('status', ['not_started', 'in_progress', 'waiting', 'completed'])->default('not_started');
+      $table->enum('status', ['not_started', 'in_progress', 'waiting', 'uncompleted', 'completed'])->default('not_started');
       $table->integer('grace_period_seconds')->default(0);
       $table->unsignedInteger('duration')->nullable(); // actual duration (in minutes)
       $table->unsignedInteger('extra_time')->default(0); // minutes of extra time

--- a/resources/js/components/LiveExamStatusTable.vue
+++ b/resources/js/components/LiveExamStatusTable.vue
@@ -135,6 +135,7 @@ const setStatus = (status: string) => {
                   'bg-green-100 text-green-800': getParticipantStatus(participant)?.status === 'completed',
                   'bg-yellow-100 text-yellow-800': getParticipantStatus(participant)?.status === 'in_progress',
                   'bg-blue-100 text-blue-800': getParticipantStatus(participant)?.status === 'not_started',
+                  'bg-red-100 text-red-800': getParticipantStatus(participant)?.status === 'uncompleted',
                 }">
                 {{ getParticipantStatus(participant)?.status?.replace('_', ' ') }}
               </span>

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -22,7 +22,7 @@ import LMT from '@/pages/LMT.vue'
 import MRTA from '@/pages/MRT-A.vue'
 import LMT2 from '@/pages/LMT2.vue'
 
-type StepStatus = 'not_started' | 'in_progress' | 'completed' | 'broken'
+type StepStatus = 'not_started' | 'in_progress' | 'completed' | 'uncompleted'
 type ExamStatus = 'not_started' | 'in_progress' | 'paused' | 'completed'
 
 const props = defineProps<{
@@ -66,7 +66,7 @@ function getStatusText(status: StepStatus) {
     not_started: 'Nicht gestartet',
     in_progress: 'In Bearbeitung',
     completed: 'Abgeschlossen',
-    broken: 'Abgebrochen',
+    uncompleted: 'Nicht abgeschlossen',
   } as const
   return map[status]
 }
@@ -222,7 +222,8 @@ onUnmounted(() => {
                   <Badge :class="cn(
                     stepStatuses[step.id]?.status === 'completed' && 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
                     stepStatuses[step.id]?.status === 'in_progress' && 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-                    stepStatuses[step.id]?.status === 'not_started' && 'bg-gray-100 text-gray-800 dark:bg-gray-600 dark:text-gray-200'
+                    stepStatuses[step.id]?.status === 'not_started' && 'bg-gray-100 text-gray-800 dark:bg-gray-600 dark:text-gray-200',
+                    stepStatuses[step.id]?.status === 'uncompleted' && 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
                   )">
                     {{ getStatusText(stepStatuses[step.id]?.status) }}
                   </Badge>

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -133,18 +133,13 @@ function requestFullscreen() {
 function handleFullscreenChange() {
   if (!document.fullscreenElement) {
     if (finishing.value) return
+    breakTest()
     fullscreenWarningOpen.value = true
   }
 }
 
-function confirmFullscreenExit() {
+function closeFullscreenWarning() {
   fullscreenWarningOpen.value = false
-  breakTest()
-}
-
-function cancelFullscreenExit() {
-  fullscreenWarningOpen.value = false
-  requestFullscreen()
 }
 
 function beginFinish() {
@@ -264,12 +259,11 @@ onUnmounted(() => {
         <DialogHeader>
           <DialogTitle>Vollbildmodus verlassen</DialogTitle>
           <DialogDescription>
-            Sie haben den Vollbildmodus verlassen. Der Test wird jetzt beendet. Klicken Sie auf „Ja“, um den Test zu beenden, oder auf „Abbrechen“, um fortzufahren.
+            Sie haben den Vollbildmodus verlassen. Der Test wurde beendet.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter class="gap-2">
-          <Button variant="secondary" @click="cancelFullscreenExit">Abbrechen</Button>
-          <Button variant="destructive" @click="confirmFullscreenExit">Ja</Button>
+          <Button @click="closeFullscreenWarning">OK</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- add `uncompleted` option to exam step status enum
- mark step as `uncompleted` when participant exits fullscreen early
- show `uncompleted` status in exam room UI with styling

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `composer install --ignore-platform-req=ext-ldap --no-interaction --no-progress` *(fails: repeated 403 errors downloading dependencies)*
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689efc03d9f8832990b33b54099732b5