### PR TITLE
Handle unfinished exam attempts

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -149,6 +149,10 @@ class ParticipantController extends Controller
       'completed_at' => now(),
     ]);
 
+    ExamParticipant::where('participant_id', $user->id)
+      ->where('exam_id', $examStepStatus->exam_id)
+      ->update(['status' => 'broken']);
+
     return back(303);
   }
 }

--- a/database/migrations/2025_08_01_081606_create_exam_participants_table.php
+++ b/database/migrations/2025_08_01_081606_create_exam_participants_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
       $table->id();
       $table->foreignId('exam_id')->constrained('exams')->cascadeOnDelete();
       $table->foreignId('participant_id')->constrained('users')->cascadeOnDelete();
-      $table->enum('status', ['not_started', 'in_progress', 'waiting', 'completed'])->default('not_started');
+      $table->enum('status', ['not_started', 'in_progress', 'waiting', 'completed', 'broken'])->default('not_started');
       $table->timestamps();
     });
   }

--- a/database/migrations/2025_08_01_081640_create_exam_step_statuses_table.php
+++ b/database/migrations/2025_08_01_081640_create_exam_step_statuses_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
       $table->foreignId('exam_id')->constrained('exams')->cascadeOnDelete();
       $table->foreignId('participant_id')->constrained('users')->cascadeOnDelete();
       $table->foreignId('exam_step_id')->constrained('exam_steps')->cascadeOnDelete();
-      $table->enum('status', ['not_started', 'in_progress', 'waiting', 'completed'])->default('not_started');
+      $table->enum('status', ['not_started', 'in_progress', 'waiting', 'completed', 'broken'])->default('not_started');
       $table->integer('grace_period_seconds')->default(0);
       $table->unsignedInteger('duration')->nullable(); // actual duration (in minutes)
       $table->unsignedInteger('extra_time')->default(0); // minutes of extra time

--- a/resources/js/components/Exams/ExamDetails.vue
+++ b/resources/js/components/Exams/ExamDetails.vue
@@ -84,8 +84,9 @@ onUnmounted(() => {
                     'bg-gray-200 text-gray-800': !p.stepStatuses[0]?.status,
                     'bg-blue-100 text-blue-800': p.stepStatuses[0]?.status === 'in_progress',
                     'bg-green-100 text-green-800': p.stepStatuses[0]?.status === 'completed',
+                    'bg-red-100 text-red-800': p.stepStatuses[0]?.status === 'broken',
                   }" class="inline-flex rounded-full px-2 text-xs font-semibold leading-5">
-                    {{ p.stepStatuses[0]?.status || 'nicht gestartet' }}
+                    {{ p.stepStatuses[0]?.status === 'broken' ? 'abgebrochen' : p.stepStatuses[0]?.status || 'nicht gestartet' }}
                   </span>
                 </td>
                 <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-500">

--- a/resources/js/components/LiveExamStatusTable.vue
+++ b/resources/js/components/LiveExamStatusTable.vue
@@ -17,6 +17,13 @@ const formatTime = (seconds: number) => {
 // We need a local copy of the exam to update the timer
 const localExam = ref(JSON.parse(JSON.stringify(props.exam)))
 
+const statusTexts: Record<string, string> = {
+  completed: 'Abgeschlossen',
+  in_progress: 'In Bearbeitung',
+  not_started: 'Nicht gestartet',
+  broken: 'Abgebrochen'
+};
+
 const getParticipantStatus = (participant: any) => {
   if (!localExam.value.current_step) {
     return null
@@ -135,8 +142,9 @@ const setStatus = (status: string) => {
                   'bg-green-100 text-green-800': getParticipantStatus(participant)?.status === 'completed',
                   'bg-yellow-100 text-yellow-800': getParticipantStatus(participant)?.status === 'in_progress',
                   'bg-blue-100 text-blue-800': getParticipantStatus(participant)?.status === 'not_started',
+                  'bg-red-100 text-red-800': getParticipantStatus(participant)?.status === 'broken',
                 }">
-                {{ getParticipantStatus(participant)?.status?.replace('_', ' ') }}
+                {{ statusTexts[getParticipantStatus(participant)?.status] ?? getParticipantStatus(participant)?.status?.replace('_', ' ') }}
               </span>
               <span v-else
                 class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -222,7 +222,8 @@ onUnmounted(() => {
                   <Badge :class="cn(
                     stepStatuses[step.id]?.status === 'completed' && 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
                     stepStatuses[step.id]?.status === 'in_progress' && 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-                    stepStatuses[step.id]?.status === 'not_started' && 'bg-gray-100 text-gray-800 dark:bg-gray-600 dark:text-gray-200'
+                    stepStatuses[step.id]?.status === 'not_started' && 'bg-gray-100 text-gray-800 dark:bg-gray-600 dark:text-gray-200',
+                    stepStatuses[step.id]?.status === 'broken' && 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
                   )">
                     {{ getStatusText(stepStatuses[step.id]?.status) }}
                   </Badge>


### PR DESCRIPTION
## Summary
- update backend to mark participant and step as `broken` when a test is exited early
- allow `broken` status in exam participant and step status tables
- show `broken` state in participant, dashboard, and admin views

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `npm install eslint-config-prettier` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: ext-ldap missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f11f85f908329b1c0482323beae36