### PR TITLE
Implement test result storage endpoint

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TestAssignment;
+use App\Models\TestResult;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class TestResultController extends Controller
+{
+  public function store(Request $request)
+  {
+    $data = $request->validate([
+      'assignment_id' => 'required|exists:test_assignments,id',
+      'result_json' => 'required|json',
+    ]);
+
+    $assignment = TestAssignment::findOrFail($data['assignment_id']);
+
+    if (Auth::id() !== $assignment->participant_id) {
+      abort(403);
+    }
+
+    TestResult::create([
+      'assignment_id' => $assignment->id,
+      'result_json' => $data['result_json'],
+    ]);
+
+    $assignment->update([
+      'status' => 'completed',
+      'started_at' => $assignment->started_at ?? now(),
+      'completed_at' => now(),
+    ]);
+
+    return response()->json(['message' => 'Result stored']);
+  }
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ExamController;
 use App\Http\Controllers\TeacherController;
 use App\Http\Controllers\ParticipantController;
 use App\Http\Controllers\ExamStepStatusController;
+use App\Http\Controllers\TestResultController;
 
 Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     // All role-protected pages
@@ -28,6 +29,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/my-exam/start-step', [ParticipantController::class, 'startStep'])->name('my-exam.start-step');
     Route::post('/my-exam/complete-step', [ParticipantController::class, 'completeStep'])->name('my-exam.complete-step');
     Route::post('/my-exam/break-step', [ParticipantController::class, 'breakStep'])->name('my-exam.break-step');
+    Route::post('/test-results', [TestResultController::class, 'store'])->name('test-results.store');
 
     // Exam management (teacher/admin only, add middleware if needed)
     Route::post('/exam-step-status/{status}/add-time', [ExamStepStatusController::class, 'addTime'])->name('exam-step-status.add-time');


### PR DESCRIPTION
## Summary
- add controller and route for storing test results

## Testing
- `composer test` *(fails: vendor/autoload.php missing; composer install requires ext-ldap and GitHub access)*

------
https://chatgpt.com/codex/tasks/task_e_689f167ed04c83298f7da585ed77ee9d