### PR TITLE
Send test results to backend

### DIFF
--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -11,10 +11,11 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
+import axios from 'axios';
 
 const page = usePage<{ auth: { user: { name: string } } }>();
 const userName = computed(() => page.props.auth?.user?.name ?? '');
-
+const props = defineProps<{ assignmentId?: number }>();
 const emit = defineEmits(['complete']);
 
 function formatTime(sec: number | null): string {
@@ -190,7 +191,7 @@ const finishTest = () => {
   endConfirmOpen.value = true;
 };
 
-const confirmEnd = () => {
+const confirmEnd = async () => {
   const now = Date.now();
   if (
     currentQuestionIndex.value >= 0 &&
@@ -205,7 +206,26 @@ const confirmEnd = () => {
   currentQuestionIndex.value = questions.value.length;
   nextButtonClickCount.value = 0;
   endConfirmOpen.value = false;
-  emit('complete');
+
+  const result = {
+    answers: userAnswers.value,
+    questionTimes: questionTimes.value,
+    finalScore: finalScore.value,
+    userPR: userPR.value,
+    userTwert: userTwert.value,
+    totalTimeTaken: totalTimeTaken.value,
+  };
+
+  try {
+    await axios.post('/test-results', {
+      assignment_id: props.assignmentId,
+      result_json: result,
+    });
+  } catch (error) {
+    console.error('Error saving test results', error);
+  } finally {
+    emit('complete');
+  }
 };
 
 const cancelEnd = () => {

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -51,6 +51,9 @@ const isTestDialogOpen = ref(false)
 const activeStepId = ref<number | null>(null)
 const page = usePage()
 const userName = computed(() => page.props.auth?.user?.name)
+const activeAssignmentId = computed(() =>
+  activeStepId.value ? props.stepStatuses[activeStepId.value]?.id : null
+)
 
 const testComponents = {
   'BRT-A': BRTA,
@@ -241,7 +244,7 @@ onUnmounted(() => {
                       <template #top-right>
                         <div class="absolute top-4 right-4 font-semibold">{{ userName }}</div>
                       </template>
-                      <component :is="activeTestComponent" class="w-full h-full" @complete="completeTest" />
+                      <component :is="activeTestComponent" class="w-full h-full" :assignment-id="activeAssignmentId" @complete="completeTest" />
                     </DialogContent>
                   </Dialog>
                 </td>

--- a/resources/js/pages/FPI-R.vue
+++ b/resources/js/pages/FPI-R.vue
@@ -20,6 +20,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
+import axios from 'axios';
 
 const page = usePage<{
   auth: {
@@ -33,6 +34,7 @@ const page = usePage<{
   };
 }>();
 const userName = computed(() => page.props.auth?.user?.name ?? '');
+const props = defineProps<{ assignmentId?: number }>();
 const emit = defineEmits(['complete']);
 
 const profile = computed(() => page.props.auth?.user?.participant_profile);
@@ -220,10 +222,26 @@ function finishTest() {
   endConfirmOpen.value = true
 }
 
-function confirmEnd() {
+async function confirmEnd() {
   handleNextBlock()
   endConfirmOpen.value = false
-  emit('complete')
+
+  const result = {
+    answers: answers.value,
+    categoryScores: categoryScores.value,
+    categoryStanines: categoryStanines.value,
+  }
+
+  try {
+    await axios.post('/test-results', {
+      assignment_id: props.assignmentId,
+      result_json: result,
+    })
+  } catch (error) {
+    console.error('Error saving test results', error)
+  } finally {
+    emit('complete')
+  }
 }
 
 function cancelEnd() {

--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -10,6 +10,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
+import axios from 'axios'
 
 import { LMT_QUESTIONS, LMTQuestion } from '@/pages/Questions/LMTQuestions'
 
@@ -19,6 +20,8 @@ const normTable = {
   "F-": [24, 30, 33, 35, 38, 41, 42, 45, 46, 49, 51, 54, 57, 58, 60, 63, 66, 71, 76],
   "F+": [33, 39, 43, 47, 50, 52.5, 55, 58, 62, 66, 75],
 }
+
+const props = defineProps<{ assignmentId?: number }>()
 
 const groupScores = computed(() => {
   const totals: Record<'L1' | 'L2' | 'F+' | 'F-', number> = {
@@ -190,10 +193,33 @@ function finishTest() {
   endConfirmOpen.value = true
 }
 
-function confirmEnd() {
+async function confirmEnd() {
   completeTest()
   endConfirmOpen.value = false
-  emit('complete')
+
+  const result = {
+    answers: userAnswers.value,
+    questionTimes: questionTimes.value,
+    groupScores: groupScores.value,
+    tValues: {
+      L1: getTValue('L1'),
+      L2: getTValue('L2'),
+      'F+': getTValue('F+'),
+      'F-': getTValue('F-'),
+    },
+    totalTimeTaken: totalTimeTaken.value,
+  }
+
+  try {
+    await axios.post('/test-results', {
+      assignment_id: props.assignmentId,
+      result_json: result,
+    })
+  } catch (error) {
+    console.error('Error saving test results', error)
+  } finally {
+    emit('complete')
+  }
 }
 
 function cancelEnd() {


### PR DESCRIPTION
## Summary
- Post test results with assignment ID on completion of each exam page
- Pass assignment IDs from ExamRoom to test pages
- Handle API post success/failure and resume exam flow

## Testing
- `npm run lint` *(fails: Cannot find module eslint-config-prettier)*
- `npm run format:check` *(fails: Cannot find package prettier-plugin-organize-imports)*
- `composer install` *(fails: ext-ldap missing)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f243cc1548329b986bee11d78b3c6