### PR TITLE
Add PDF generation for test results

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TestResult;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Barryvdh\DomPDF\Facade\Pdf;
+
+class TestResultController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'assignment_id' => ['required', 'exists:test_assignments,id'],
+            'result_json' => ['required', 'array'],
+        ]);
+
+        $result = TestResult::create([
+            'assignment_id' => $data['assignment_id'],
+            'result_json' => $data['result_json'],
+        ]);
+
+        $pdf = Pdf::loadView('pdf.test-result', ['result' => $data['result_json']]);
+        $path = 'results/' . $result->id . '.pdf';
+        Storage::disk('public')->put($path, $pdf->output());
+        $result->update(['pdf_file_path' => $path]);
+
+        return response()->json($result, 201);
+    }
+
+    public function download(TestResult $testResult)
+    {
+        if (!$testResult->pdf_file_path || !Storage::disk('public')->exists($testResult->pdf_file_path)) {
+            abort(404);
+        }
+
+        return Storage::disk('public')->download($testResult->pdf_file_path);
+    }
+}

--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -13,6 +13,10 @@ class TestResult extends Model
     'pdf_file_path',
   ];
 
+  protected $casts = [
+    'result_json' => 'array',
+  ];
+
   // Assignment for which this result belongs
   public function assignment(): BelongsTo
   {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "barryvdh/laravel-dompdf": "^2.0",
         "directorytree/ldaprecord-laravel": "^3.4",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",

--- a/resources/views/pdf/test-result.blade.php
+++ b/resources/views/pdf/test-result.blade.php
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Result</title>
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ddd; padding: 4px; text-align: left; }
+        th { background: #f5f5f5; }
+    </style>
+</head>
+<body>
+<h1>Test Result</h1>
+<table>
+    @foreach($result as $key => $value)
+        <tr>
+            <th>{{ $key }}</th>
+            <td>
+                @if(is_array($value))
+                    {{ json_encode($value) }}
+                @else
+                    {{ $value }}
+                @endif
+            </td>
+        </tr>
+    @endforeach
+</table>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ExamController;
 use App\Http\Controllers\TeacherController;
 use App\Http\Controllers\ParticipantController;
 use App\Http\Controllers\ExamStepStatusController;
+use App\Http\Controllers\TestResultController;
 
 Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     // All role-protected pages
@@ -46,6 +47,9 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/exams/store-with-participants', [ExamController::class, 'storeWithParticipants'])->name('exams.storeWithParticipants');
     Route::put('/exams/{exam}/steps', [ExamController::class, 'updateSteps'])->name('exams.updateSteps');
     Route::get('/api/active-exams', [ExamController::class, 'getActiveExams'])->name('api.active-exams');
+
+    Route::post('test-results', [TestResultController::class, 'store'])->name('test-results.store');
+    Route::get('test-results/{testResult}/pdf', [TestResultController::class, 'download'])->name('test-results.pdf');
 });
 
 Route::get('/login', function () {

--- a/storage/app/public/.gitignore
+++ b/storage/app/public/.gitignore
@@ -1,2 +1,4 @@
 *
+!results/
+!results/.gitignore
 !.gitignore

--- a/storage/app/public/results/.gitignore
+++ b/storage/app/public/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- add barryvdh/laravel-dompdf requirement
- generate and store test result PDFs
- serve stored result PDFs with authenticated route

## Testing
- `composer install` *(fails: Required package "barryvdh/laravel-dompdf" is not present in the lock file)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689f243db098832990e4cf21bcdfdea1