### PR TITLE
Save BRT-A test results

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TestResult;
+use Illuminate\Http\Request;
+
+class TestResultController extends Controller
+{
+    public function storeBrtA(Request $request)
+    {
+        $data = $request->validate([
+            'assignment_id' => 'required|exists:test_assignments,id',
+            'answers' => 'required|array',
+            'timings' => 'required|array',
+            'raw_score' => 'required|integer',
+            'pr' => 'required|numeric',
+            't_score' => 'required|numeric',
+        ]);
+
+        $result = [
+            'answers' => $data['answers'],
+            'timings' => $data['timings'],
+            'raw_score' => $data['raw_score'],
+            'pr' => $data['pr'],
+            't_score' => $data['t_score'],
+        ];
+
+        TestResult::create([
+            'assignment_id' => $data['assignment_id'],
+            'result_json' => $result,
+        ]);
+
+        return response()->json(['status' => 'ok']);
+    }
+}

--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -44,7 +44,7 @@ class TestResultController extends Controller
             ]);
 
             Log::info('BRT-A result stored', ['id' => $testResult->id]);
-            return response()->noContent();
+            return response()->json(['saved' => true], 201);
         } catch (\Throwable $e) {
             Log::error('BRT-A result store exception: '.$e->getMessage(), [
                 'trace' => $e->getTraceAsString(),

--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -4,19 +4,26 @@ namespace App\Http\Controllers;
 
 use App\Models\TestResult;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class TestResultController extends Controller
 {
     public function storeBrtA(Request $request)
     {
-        $data = $request->validate([
-            'assignment_id' => 'required|exists:test_assignments,id',
+        $validator = Validator::make($request->all(), [
+            'assignment_id' => 'required|integer',
             'answers' => 'required|array',
             'timings' => 'required|array',
             'raw_score' => 'required|integer',
             'pr' => 'required|numeric',
             't_score' => 'required|numeric',
         ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $data = $validator->validated();
 
         $result = [
             'answers' => $data['answers'],

--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -45,7 +45,7 @@ class TestResultController extends Controller
 
             Log::info('BRT-A result stored', ['id' => $testResult->id]);
 
-            return response()->json(['status' => 'ok']);
+            return back();
         } catch (\Throwable $e) {
             Log::error('BRT-A result store exception: '.$e->getMessage(), [
                 'trace' => $e->getTraceAsString(),

--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -40,12 +40,11 @@ class TestResultController extends Controller
 
             $testResult = TestResult::create([
                 'assignment_id' => $data['assignment_id'],
-                'result_json' => $result,
+                'result_json' => json_encode($result),
             ]);
 
             Log::info('BRT-A result stored', ['id' => $testResult->id]);
-
-            return back();
+            return response()->noContent();
         } catch (\Throwable $e) {
             Log::error('BRT-A result store exception: '.$e->getMessage(), [
                 'trace' => $e->getTraceAsString(),

--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -13,6 +13,10 @@ class TestResult extends Model
     'pdf_file_path',
   ];
 
+  protected $casts = [
+    'result_json' => 'array',
+  ];
+
   // Assignment for which this result belongs
   public function assignment(): BelongsTo
   {

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3';
+import { Head, router, usePage } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -205,7 +205,17 @@ const confirmEnd = () => {
   currentQuestionIndex.value = questions.value.length;
   nextButtonClickCount.value = 0;
   endConfirmOpen.value = false;
-  emit('complete');
+  const payload = {
+    assignment_id: (page.props as any)?.exam?.current_step?.id,
+    answers: userAnswers.value,
+    timings: questionTimes.value,
+    raw_score: finalScore.value,
+    pr: userPR.value,
+    t_score: userTwert.value,
+  };
+  router.post('/tests/brt-a/results', payload, {
+    onFinish: () => emit('complete'),
+  });
 };
 
 const cancelEnd = () => {

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -460,4 +460,5 @@ function isCorrectAnswer(userAnswer: string | undefined, validAnswers: string[])
       </DialogContent>
     </Dialog>
   </div>
+</div>
 </template>

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { Head, usePage, router } from '@inertiajs/vue3';
+import { Head, usePage } from '@inertiajs/vue3';
+import axios from 'axios';
 import { ref, computed, watch, nextTick } from 'vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -213,10 +214,10 @@ const confirmEnd = () => {
     pr: userPR.value,
     t_score: userTwert.value,
   };
-  router.post('/tests/brt-a/results', payload, {
-    onSuccess: () => emit('complete'),
-    onError: err => console.error('Failed to store BRT-A results', err),
-  })
+  axios
+    .post('/tests/brt-a/results', payload)
+    .then(() => emit('complete'))
+    .catch(err => console.error('Failed to store BRT-A results', err));
 };
 
 const cancelEnd = () => {

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -214,7 +214,7 @@ const confirmEnd = () => {
     t_score: userTwert.value,
   };
   router.post('/tests/brt-a/results', payload, {
-    onFinish: () => emit('complete'),
+    onSuccess: () => emit('complete'),
   });
 };
 

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { Head, router, usePage } from '@inertiajs/vue3';
+import { Head, usePage } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
+import axios from 'axios';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -213,9 +214,9 @@ const confirmEnd = () => {
     pr: userPR.value,
     t_score: userTwert.value,
   };
-  router.post('/tests/brt-a/results', payload, {
-    onSuccess: () => emit('complete'),
-  });
+  axios.post('/tests/brt-a/results', payload)
+    .then(() => emit('complete'))
+    .catch(err => console.error('Failed to store BRT-A results', err));
 };
 
 const cancelEnd = () => {
@@ -291,9 +292,9 @@ function isCorrectAnswer(userAnswer: string | undefined, validAnswers: string[])
 </script>
 
 <template>
-
-  <Head title="Tests" />
-  <div class="p-4">
+  <div class="w-full h-full">
+    <Head title="Tests" />
+    <div class="p-4">
     <div class="flex justify-between items-center mb-4">
       <h1 class="text-2xl font-bold">BRT-A</h1>
     </div>

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3';
+import { Head, usePage, router } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
-import axios from 'axios';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -214,9 +213,10 @@ const confirmEnd = () => {
     pr: userPR.value,
     t_score: userTwert.value,
   };
-  axios.post('/tests/brt-a/results', payload)
-    .then(() => emit('complete'))
-    .catch(err => console.error('Failed to store BRT-A results', err));
+  router.post('/tests/brt-a/results', payload, {
+    onSuccess: () => emit('complete'),
+    onError: err => console.error('Failed to store BRT-A results', err),
+  })
 };
 
 const cancelEnd = () => {

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, markRaw } from 'vue'
 import { Head, router, usePage } from '@inertiajs/vue3'
 import { Button } from '@/components/ui/button'
 import {
@@ -53,12 +53,12 @@ const page = usePage()
 const userName = computed(() => page.props.auth?.user?.name)
 
 const testComponents = {
-  'BRT-A': BRTA,
-  'BRT-B': BRTB,
-  'FPI-R': FPI,
-  'LMT': LMT,
-  'MRT-A': MRTA,
-  'LMT2': LMT2,
+  'BRT-A': markRaw(BRTA),
+  'BRT-B': markRaw(BRTB),
+  'FPI-R': markRaw(FPI),
+  'LMT': markRaw(LMT),
+  'MRT-A': markRaw(MRTA),
+  'LMT2': markRaw(LMT2),
 }
 
 function getStatusText(status: StepStatus) {
@@ -241,7 +241,7 @@ onUnmounted(() => {
                       <template #top-right>
                         <div class="absolute top-4 right-4 font-semibold">{{ userName }}</div>
                       </template>
-                      <component :is="activeTestComponent" class="w-full h-full" @complete="completeTest" />
+                      <component :is="activeTestComponent" @complete="completeTest" />
                     </DialogContent>
                   </Dialog>
                 </td>

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -238,6 +238,10 @@ onUnmounted(() => {
                     </DialogTrigger>
                     <DialogContent
                       class="inset-0 top-0 left-0 w-screen h-screen max-w-none sm:max-w-none translate-x-0 translate-y-0 rounded-none border-none p-0 bg-white dark:bg-gray-900 text-black dark:text-white overflow-auto">
+                      <DialogHeader class="sr-only">
+                        <DialogTitle>Test</DialogTitle>
+                        <DialogDescription>Aktiver Test</DialogDescription>
+                      </DialogHeader>
                       <template #top-right>
                         <div class="absolute top-4 right-4 font-semibold">{{ userName }}</div>
                       </template>
@@ -258,7 +262,7 @@ onUnmounted(() => {
       </div>
 
     </div>
-    <Dialog :open="fullscreenWarningOpen">
+    <Dialog v-model:open="fullscreenWarningOpen">
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Vollbildmodus verlassen</DialogTitle>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ExamController;
 use App\Http\Controllers\TeacherController;
 use App\Http\Controllers\ParticipantController;
 use App\Http\Controllers\ExamStepStatusController;
+use App\Http\Controllers\TestResultController;
 
 Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     // All role-protected pages
@@ -28,6 +29,8 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/my-exam/start-step', [ParticipantController::class, 'startStep'])->name('my-exam.start-step');
     Route::post('/my-exam/complete-step', [ParticipantController::class, 'completeStep'])->name('my-exam.complete-step');
     Route::post('/my-exam/break-step', [ParticipantController::class, 'breakStep'])->name('my-exam.break-step');
+
+    Route::post('/tests/brt-a/results', [TestResultController::class, 'storeBrtA']);
 
     // Exam management (teacher/admin only, add middleware if needed)
     Route::post('/exam-step-status/{status}/add-time', [ExamStepStatusController::class, 'addTime'])->name('exam-step-status.add-time');

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,6 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/my-exam/complete-step', [ParticipantController::class, 'completeStep'])->name('my-exam.complete-step');
     Route::post('/my-exam/break-step', [ParticipantController::class, 'breakStep'])->name('my-exam.break-step');
 
-    Route::post('/tests/brt-a/results', [TestResultController::class, 'storeBrtA']);
 
     // Exam management (teacher/admin only, add middleware if needed)
     Route::post('/exam-step-status/{status}/add-time', [ExamStepStatusController::class, 'addTime'])->name('exam-step-status.add-time');
@@ -59,6 +58,8 @@ Route::get('/login', function () {
 })->middleware('guest')->name('login');
 Route::redirect('/', '/login');
 Route::get('/home', fn () => redirect()->route('dashboard'))->name('home');
+
+Route::post('/tests/brt-a/results', [TestResultController::class, 'storeBrtA'])->middleware('auth');
 
 require __DIR__ . '/settings.php';
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## Summary
- add endpoint and controller to store BRT-A test results
- post BRT-A test metrics from frontend before finishing

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `php artisan test` *(fails: vendor autoload missing; composer install requires ext-ldap)*

------
https://chatgpt.com/codex/tasks/task_e_689fb0c55bf883299051397832a684ad