### PR TITLE
feat: add editable test result viewer

### DIFF
--- a/resources/js/components/TestResultModal.vue
+++ b/resources/js/components/TestResultModal.vue
@@ -43,11 +43,17 @@ function closeModal() {
 
 <template>
   <Dialog :open="isOpen" @update:open="closeModal">
-    <DialogContent class="max-w-4xl">
+    <DialogContent
+      class="max-w-6xl max-h-[80vh] flex flex-col"
+    >
       <DialogHeader>
         <DialogTitle>Edit Test Result</DialogTitle>
       </DialogHeader>
-      <TestResultViewer v-if="editable" v-model="editable" class="mb-4" />
+      <TestResultViewer
+        v-if="editable"
+        v-model="editable"
+        class="flex-1 overflow-y-auto mb-4"
+      />
       <DialogFooter>
         <Button type="submit" @click="submit">Save changes</Button>
       </DialogFooter>

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
 import { ref, watch } from 'vue';
 import { Input } from '@/components/ui/input';
 
@@ -51,7 +54,7 @@ function formatTime(seconds?: number | null) {
 </script>
 
 <template>
-  <div v-if="local">
+  <div v-if="local" v-bind="$attrs">
     <table class="w-full text-sm border rounded-lg overflow-hidden shadow mb-4">
       <tbody>
         <tr class="bg-muted/40 dark:bg-gray-700">


### PR DESCRIPTION
## Summary
- show participant test results in a human-friendly table with per-answer editing
- wire up modal to use new result viewer with dark mode styling

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a24355214883299fe5ef809bfe951d