### PR TITLE
Preserve participant test modal after editing results

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -17,6 +17,6 @@ class TestResultController extends Controller
             'result_json' => json_decode($validatedData['result_json'], true),
         ]);
 
-        return redirect()->back()->with('success', 'Test result updated successfully.');
+        return back(303)->with('success', 'Test result updated successfully.');
     }
 }

--- a/resources/js/components/TestResultModal.vue
+++ b/resources/js/components/TestResultModal.vue
@@ -29,9 +29,7 @@ function submit() {
   if (props.testResult && editable.value) {
     form.result_json = JSON.stringify(editable.value);
     form.put(route('test-results.update', { testResult: props.testResult.id }), {
-      onSuccess: () => {
-        closeModal();
-      },
+      preserveState: true,
     });
   }
 }

--- a/resources/js/pages/Participants/List.vue
+++ b/resources/js/pages/Participants/List.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -23,6 +23,21 @@ function closeModal() {
     isModalOpen.value = false;
     selectedTestResult.value = null;
 }
+
+watch(
+  () => props.participants,
+  (participants) => {
+    if (selectedTestResult.value) {
+      const updated = participants
+        .flatMap((p: any) => p.test_assignments)
+        .flatMap((a: any) => a.results)
+        .find((r: any) => r.id === selectedTestResult.value.id);
+      if (updated) {
+        selectedTestResult.value = updated;
+      }
+    }
+  }
+);
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- Keep test result modal state when saving edits
- Refresh selected result when participant list updates
- Redirect with 303 after saving a result

## Testing
- `npm test` *(fails: Missing script: "test")*
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: ext-ldap missing, subsequent downloads require GitHub auth)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f0a0b64083298d429c955b428160