### PR TITLE
Capture test charts to PDF on completion

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -138,6 +138,10 @@ class ParticipantController extends Controller
     ]);
 
     $results = $request->input('results');
+    $pdfPath = null;
+    if ($request->hasFile('pdf')) {
+      $pdfPath = $request->file('pdf')->store('test_results', 'public');
+    }
 
     if ($results) {
       $examStep = $examStepStatus->step;
@@ -155,6 +159,7 @@ class ParticipantController extends Controller
         TestResult::create([
           'assignment_id' => $assignment->id,
           'result_json' => $results,
+          'pdf_file_path' => $pdfPath,
         ]);
 
         $assignment->update([

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^2.5.1",
         "laravel-vite-plugin": "^1.0",
         "lucide-vue-next": "^0.468.0",
         "radix-vue": "^1.9.17",

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -87,12 +87,15 @@ function startTest(step: any) {
   })
 }
 
-function completeTest(results: any) {
+function completeTest(results: any, pdf?: Blob | null) {
   if (!activeStepId.value) return;
-  router.post('/my-exam/complete-step', {
+  const data: Record<string, any> = {
     exam_step_id: activeStepId.value,
     results: results
-  }, {
+  };
+  if (pdf) data.pdf = pdf;
+  router.post('/my-exam/complete-step', data, {
+    forceFormData: true,
     onSuccess: () => {
       isTestDialogOpen.value = false
       window.removeEventListener('beforeunload', handleBeforeUnload)


### PR DESCRIPTION
## Summary
- Capture MRT-A result charts as a PDF on the client using html2canvas and jsPDF
- Send optional PDF to backend when completing exam steps and persist file path
- Update exam completion flow to upload PDFs alongside results

## Testing
- `npm install jspdf html2canvas` *(fails: 403 Forbidden)*
- `npm install --package-lock-only` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fd681e18832999bca6d6cc2e8ec5