### PR TITLE
Add backend scoring and PDF export for MRT-A

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -222,6 +222,26 @@ class ParticipantController extends Controller
     return back(303);
   }
 
+  public function mrtAResult()
+  {
+    $user = Auth::user();
+    $assignment = TestAssignment::where('participant_id', $user->id)
+      ->whereHas('test', function ($q) {
+        $q->where('name', 'MRT-A');
+      })
+      ->with('results')
+      ->first();
+
+    $result = null;
+    if ($assignment && $assignment->results->isNotEmpty()) {
+      $result = $assignment->results->last()->result_json;
+    }
+
+    return Inertia::render('Scores/MRT-AResult', [
+      'result' => $result,
+    ]);
+  }
+
   public function list()
     {
         $user = Auth::user();

--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -158,6 +158,12 @@ class ParticipantController extends Controller
           $answers = $results['answers'] ?? [];
           $times = $results['question_times'] ?? [];
           $resultData = \App\Services\BrtAScorer::score($answers, $times);
+        } elseif ($examStep->test->name === 'MRT-A') {
+          $answers = $results['answers'] ?? [];
+          $times = $results['question_times'] ?? [];
+          $profile = $user->participant_profile;
+          $age = $profile->age ?? null;
+          $resultData = \App\Services\MrtAScorer::score($answers, $times, $age);
         } elseif ($examStep->test->name === 'FPI-R') {
           $answers = $results['answers'] ?? [];
           $totalTime = $results['total_time_seconds'] ?? null;
@@ -174,6 +180,12 @@ class ParticipantController extends Controller
 
         if ($examStep->test->name === 'BRT-A') {
           $pdfPath = \App\Services\BrtAPdfService::generate($testResult);
+          if ($pdfPath) {
+            $testResult->update(['pdf_file_path' => $pdfPath]);
+          }
+        }
+        if ($examStep->test->name === 'MRT-A') {
+          $pdfPath = \App\Services\MrtAPdfService::generate($testResult);
           if ($pdfPath) {
             $testResult->update(['pdf_file_path' => $pdfPath]);
           }

--- a/app/Services/MrtAPdfService.php
+++ b/app/Services/MrtAPdfService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TestResult;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class MrtAPdfService
+{
+    public static function generate(TestResult $result): ?string
+    {
+        if (!class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
+            return null;
+        }
+
+        $assignment = $result->assignment;
+        $participantName = $assignment->participant->name ?? 'participant';
+        $testName = $assignment->test->name ?? 'test';
+        $durationSeconds = $result->result_json['total_time_seconds'] ?? 0;
+        $durationFormatted = gmdate('i:s', $durationSeconds);
+
+        $data = [
+            'test_name' => $testName,
+            'date' => now()->format('d.m.Y'),
+            'participant_name' => $participantName,
+            'duration' => $durationFormatted,
+            'group_scores' => $result->result_json['group_scores'] ?? [],
+            'group_stanines' => $result->result_json['group_stanines'] ?? [],
+            'total_score' => $result->result_json['total_score'] ?? null,
+            'prozentrang' => $result->result_json['prozentrang'] ?? null,
+        ];
+
+        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('pdfs.mrt-a-result', $data)->setPaper('a4');
+        $fileName = Str::slug($participantName, '_') . '_' . Str::slug($testName, '_') . '.pdf';
+        $path = 'test_results/' . $fileName;
+        Storage::put($path, $pdf->output());
+        return $path;
+    }
+}

--- a/app/Services/MrtAPdfService.php
+++ b/app/Services/MrtAPdfService.php
@@ -29,6 +29,7 @@ class MrtAPdfService
             'group_stanines' => $result->result_json['group_stanines'] ?? [],
             'total_score' => $result->result_json['total_score'] ?? null,
             'prozentrang' => $result->result_json['prozentrang'] ?? null,
+            'answers' => $result->result_json['answers'] ?? [],
         ];
 
         $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('pdfs.mrt-a-result', $data)->setPaper('a4');

--- a/app/Services/MrtAScorer.php
+++ b/app/Services/MrtAScorer.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Services;
+
+class MrtAScorer
+{
+    protected static array $questions = [
+        ['number' => 1, 'correct' => ['D']],
+        ['number' => 2, 'correct' => ['A']],
+        ['number' => 3, 'correct' => ['C']],
+        ['number' => 4, 'correct' => ['C']],
+        ['number' => 5, 'correct' => ['A']],
+        ['number' => 6, 'correct' => ['B']],
+        ['number' => 7, 'correct' => ['C']],
+        ['number' => 8, 'correct' => ['D']],
+        ['number' => 9, 'correct' => ['C', 'D']],
+        ['number' => 10, 'correct' => ['D']],
+        ['number' => 11, 'correct' => ['D']],
+        ['number' => 12, 'correct' => ['C']],
+        ['number' => 13, 'correct' => ['D']],
+        ['number' => 14, 'correct' => ['D']],
+        ['number' => 15, 'correct' => ['B']],
+        ['number' => 16, 'correct' => ['A']],
+        ['number' => 17, 'correct' => ['A']],
+        ['number' => 18, 'correct' => ['D']],
+        ['number' => 19, 'correct' => ['B']],
+        ['number' => 20, 'correct' => ['B']],
+        ['number' => 21, 'correct' => ['A']],
+        ['number' => 22, 'correct' => ['A']],
+        ['number' => 23, 'correct' => ['C']],
+        ['number' => 24, 'correct' => ['B']],
+        ['number' => 25, 'correct' => ['C']],
+        ['number' => 26, 'correct' => ['D']],
+        ['number' => 27, 'correct' => ['D']],
+        ['number' => 28, 'correct' => ['D']],
+        ['number' => 29, 'correct' => ['B']],
+        ['number' => 30, 'correct' => ['C']],
+        ['number' => 31, 'correct' => ['C']],
+        ['number' => 32, 'correct' => ['B']],
+        ['number' => 33, 'correct' => ['A']],
+        ['number' => 34, 'correct' => ['B']],
+        ['number' => 35, 'correct' => ['D']],
+        ['number' => 36, 'correct' => ['B']],
+        ['number' => 37, 'correct' => ['A']],
+        ['number' => 38, 'correct' => ['B']],
+        ['number' => 39, 'correct' => ['D']],
+        ['number' => 40, 'correct' => ['D']],
+        ['number' => 41, 'correct' => ['B']],
+        ['number' => 42, 'correct' => ['A']],
+        ['number' => 43, 'correct' => ['A']],
+        ['number' => 44, 'correct' => ['C']],
+        ['number' => 45, 'correct' => ['B']],
+        ['number' => 46, 'correct' => ['A']],
+        ['number' => 47, 'correct' => ['B']],
+        ['number' => 48, 'correct' => ['C']],
+        ['number' => 49, 'correct' => ['A']],
+        ['number' => 50, 'correct' => ['D']],
+        ['number' => 51, 'correct' => ['D']],
+        ['number' => 52, 'correct' => ['B']],
+        ['number' => 53, 'correct' => ['D']],
+        ['number' => 54, 'correct' => ['A', 'C']],
+        ['number' => 55, 'correct' => ['A', 'C']],
+        ['number' => 56, 'correct' => ['B']],
+        ['number' => 57, 'correct' => ['D']],
+        ['number' => 58, 'correct' => ['C']],
+        ['number' => 59, 'correct' => ['D']],
+        ['number' => 60, 'correct' => ['D']],
+    ];
+
+    protected static array $groupMap = [
+        [0,1,2,3,4,15,16,17,18,19],
+        [5,6,7,8,9,20,21,22,23,24],
+        [10,11,12,13,14,25,26,27,28,29],
+        [30,31,32,33,34,45,46,47,48,49],
+        [35,36,37,38,39,50,51,52,53,54],
+        [40,41,42,43,44,55,56,57,58,59],
+    ];
+
+    protected static array $snMatrix18_30 = [
+        [1,1,1,1,2,3,3,4,5,6,9],
+        [1,1,1,2,3,4,5,6,7,8,9],
+        [1,1,1,1,2,2,3,4,5,7,9],
+        [1,1,1,1,1,1,2,3,4,6,9],
+        [1,1,2,3,4,4,5,6,7,9,9],
+        [1,1,1,1,2,3,3,4,5,7,9],
+    ];
+
+    protected static array $snMatrix31_50 = [
+        [1,1,1,2,2,3,4,5,5,7,9],
+        [1,1,1,1,2,3,4,4,5,6,9],
+        [1,1,1,2,2,3,4,5,6,7,9],
+        [1,1,1,1,1,2,2,3,4,6,9],
+        [1,2,2,4,4,5,6,7,8,9,9],
+        [1,1,1,2,3,3,4,5,6,7,9],
+    ];
+
+    protected static array $prTable18_30 = [
+        ['rwgs'=>9,'pr'=>0], ['rwgs'=>10,'pr'=>0], ['rwgs'=>11,'pr'=>0], ['rwgs'=>12,'pr'=>0], ['rwgs'=>13,'pr'=>0], ['rwgs'=>14,'pr'=>0],
+        ['rwgs'=>15,'pr'=>0], ['rwgs'=>16,'pr'=>0], ['rwgs'=>17,'pr'=>0], ['rwgs'=>18,'pr'=>1], ['rwgs'=>19,'pr'=>1], ['rwgs'=>20,'pr'=>1],
+        ['rwgs'=>21,'pr'=>2], ['rwgs'=>22,'pr'=>2], ['rwgs'=>23,'pr'=>3], ['rwgs'=>24,'pr'=>3], ['rwgs'=>25,'pr'=>3], ['rwgs'=>26,'pr'=>3],
+        ['rwgs'=>27,'pr'=>3], ['rwgs'=>28,'pr'=>4], ['rwgs'=>29,'pr'=>5], ['rwgs'=>30,'pr'=>7], ['rwgs'=>31,'pr'=>8], ['rwgs'=>32,'pr'=>10],
+        ['rwgs'=>33,'pr'=>12], ['rwgs'=>34,'pr'=>13], ['rwgs'=>35,'pr'=>16], ['rwgs'=>36,'pr'=>18], ['rwgs'=>37,'pr'=>18], ['rwgs'=>38,'pr'=>21],
+        ['rwgs'=>39,'pr'=>24], ['rwgs'=>40,'pr'=>27], ['rwgs'=>41,'pr'=>31], ['rwgs'=>42,'pr'=>34], ['rwgs'=>43,'pr'=>38], ['rwgs'=>44,'pr'=>42],
+        ['rwgs'=>45,'pr'=>46], ['rwgs'=>46,'pr'=>50], ['rwgs'=>47,'pr'=>54], ['rwgs'=>48,'pr'=>58], ['rwgs'=>49,'pr'=>62], ['rwgs'=>50,'pr'=>69],
+        ['rwgs'=>51,'pr'=>73], ['rwgs'=>52,'pr'=>79], ['rwgs'=>53,'pr'=>84], ['rwgs'=>54,'pr'=>88], ['rwgs'=>55,'pr'=>93], ['rwgs'=>56,'pr'=>96],
+        ['rwgs'=>57,'pr'=>98], ['rwgs'=>58,'pr'=>99], ['rwgs'=>59,'pr'=>100], ['rwgs'=>60,'pr'=>100],
+    ];
+
+    protected static array $prTable31_50 = [
+        ['rwgs'=>9,'pr'=>0], ['rwgs'=>10,'pr'=>0], ['rwgs'=>11,'pr'=>0], ['rwgs'=>12,'pr'=>0], ['rwgs'=>13,'pr'=>0], ['rwgs'=>14,'pr'=>0],
+        ['rwgs'=>15,'pr'=>1], ['rwgs'=>16,'pr'=>1], ['rwgs'=>17,'pr'=>1], ['rwgs'=>18,'pr'=>1], ['rwgs'=>19,'pr'=>3], ['rwgs'=>20,'pr'=>3],
+        ['rwgs'=>21,'pr'=>3], ['rwgs'=>22,'pr'=>3], ['rwgs'=>23,'pr'=>4], ['rwgs'=>24,'pr'=>5], ['rwgs'=>25,'pr'=>5], ['rwgs'=>26,'pr'=>7],
+        ['rwgs'=>27,'pr'=>8], ['rwgs'=>28,'pr'=>10], ['rwgs'=>29,'pr'=>10], ['rwgs'=>30,'pr'=>12], ['rwgs'=>31,'pr'=>13], ['rwgs'=>32,'pr'=>13],
+        ['rwgs'=>33,'pr'=>16], ['rwgs'=>34,'pr'=>18], ['rwgs'=>35,'pr'=>21], ['rwgs'=>36,'pr'=>21], ['rwgs'=>37,'pr'=>24], ['rwgs'=>38,'pr'=>27],
+        ['rwgs'=>39,'pr'=>31], ['rwgs'=>40,'pr'=>34], ['rwgs'=>41,'pr'=>38], ['rwgs'=>42,'pr'=>42], ['rwgs'=>43,'pr'=>42], ['rwgs'=>44,'pr'=>46],
+        ['rwgs'=>45,'pr'=>50], ['rwgs'=>46,'pr'=>58], ['rwgs'=>47,'pr'=>62], ['rwgs'=>48,'pr'=>62], ['rwgs'=>49,'pr'=>66], ['rwgs'=>50,'pr'=>79],
+        ['rwgs'=>51,'pr'=>79], ['rwgs'=>52,'pr'=>82], ['rwgs'=>53,'pr'=>84], ['rwgs'=>54,'pr'=>86], ['rwgs'=>55,'pr'=>90], ['rwgs'=>56,'pr'=>95],
+        ['rwgs'=>57,'pr'=>98], ['rwgs'=>58,'pr'=>99], ['rwgs'=>59,'pr'=>100], ['rwgs'=>60,'pr'=>100],
+    ];
+
+    public static function score(array $answers, array $times, ?int $age): array
+    {
+        $details = [];
+        $correctFlags = [];
+        foreach (self::$questions as $index => $q) {
+            $user = $answers[$index] ?? null;
+            $isCorrect = self::isCorrect($user, $q['correct']);
+            $correctFlags[$index] = $isCorrect ? 1 : 0;
+            $details[] = [
+                'number' => $q['number'],
+                'user_answer' => $user,
+                'correct_answers' => $q['correct'],
+                'time_seconds' => $times[$index] ?? 0,
+                'is_correct' => $isCorrect,
+            ];
+        }
+
+        $groupScores = [];
+        foreach (self::$groupMap as $group) {
+            $sum = 0;
+            foreach ($group as $idx) {
+                $sum += $correctFlags[$idx] ?? 0;
+            }
+            $groupScores[] = $sum;
+        }
+
+        $matrix = ($age !== null && $age >= 31) ? self::$snMatrix31_50 : self::$snMatrix18_30;
+        $groupStanines = [];
+        foreach ($groupScores as $gIdx => $score) {
+            $safe = max(0, min(10, $score));
+            $groupStanines[] = $matrix[$gIdx][$safe] ?? null;
+        }
+
+        $totalScore = array_sum($groupScores);
+        $prTable = ($age !== null && $age >= 31) ? self::$prTable31_50 : self::$prTable18_30;
+        $pr = 0;
+        foreach ($prTable as $row) {
+            if ($row['rwgs'] === $totalScore) {
+                $pr = $row['pr'];
+                break;
+            }
+        }
+
+        $totalTime = array_sum($times);
+
+        return [
+            'group_scores' => $groupScores,
+            'group_stanines' => $groupStanines,
+            'total_score' => $totalScore,
+            'prozentrang' => $pr,
+            'total_time_seconds' => $totalTime,
+            'answers' => $details,
+        ];
+    }
+
+    protected static function isCorrect(?string $user, array $valid): bool
+    {
+        if (!$user) {
+            return false;
+        }
+        $u = strtoupper(trim($user));
+        foreach ($valid as $v) {
+            if ($u === strtoupper(trim($v))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/resources/js/pages/Scores/MRT-AResult.vue
+++ b/resources/js/pages/Scores/MRT-AResult.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+import { Button } from '@/components/ui/button';
+import { Line } from 'vue-chartjs';
+import {
+  Chart,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  Tooltip,
+  Legend,
+  Title,
+  registerables,
+} from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+
+Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Tooltip, Legend, Title);
+Chart.register(...registerables, annotationPlugin);
+
+type MrtAResult = {
+  group_scores: number[];
+  group_stanines: number[];
+  total_score: number;
+  prozentrang: number;
+  total_time_seconds?: number;
+  answers: Array<{
+    number: number;
+    user_answer: string | null;
+    correct_answers: string[];
+    time_seconds: number;
+    is_correct: boolean;
+  }>;
+};
+
+const props = defineProps<{ result: MrtAResult | null }>();
+const showDetails = ref(false);
+
+function formatTime(sec: number | null | undefined): string {
+  if (sec == null || isNaN(sec)) return '–';
+  if (sec < 60) return `${sec} Sekunden`;
+  const min = Math.round(sec / 60);
+  return `${min} Minuten`;
+}
+
+const groupScores = computed(() => props.result?.group_scores ?? []);
+const groupStanines = computed(() => props.result?.group_stanines ?? []);
+const totalScore = computed(() => props.result?.total_score ?? 0);
+const prValue = computed(() => props.result?.prozentrang ?? 0);
+
+const chartData = computed(() => ({
+  labels: ['U1', 'U2', 'U3', 'U4', 'U5', 'U6'],
+  datasets: [
+    {
+      label: 'SN',
+      data: groupStanines.value,
+      borderColor: '#1d4ed8',
+      borderWidth: 2,
+      tension: 0,
+      pointRadius: 6,
+      pointBackgroundColor: '#1d4ed8',
+      fill: false,
+    },
+  ],
+}));
+
+const chartOptions = {
+  responsive: true,
+  plugins: {
+    legend: { display: false },
+    title: { display: false },
+    annotation: {
+      annotations: {
+        rangeBox: {
+          type: 'box',
+          xMin: 4,
+          xMax: 6,
+          backgroundColor: 'rgba(144,238,144,0.3)',
+          borderWidth: 0,
+        },
+      },
+    },
+  },
+  indexAxis: 'y' as const,
+  scales: {
+    x: {
+      min: 1,
+      max: 9,
+      ticks: { stepSize: 1 },
+    },
+  },
+};
+</script>
+
+<template>
+  <Head title="MRT-A Ergebnis" />
+  <div class="p-6">
+    <h1 class="text-2xl font-bold mb-6">MRT-A Ergebnis</h1>
+    <div v-if="props.result" class="flex flex-col items-center">
+      <div class="mb-6 w-full max-w-md">
+        <table class="w-full text-sm border rounded-lg overflow-hidden shadow">
+          <tbody>
+            <tr class="bg-muted/40">
+              <td class="font-semibold px-3 py-2 w-1/2">Rohwert</td>
+              <td class="px-3 py-2">{{ totalScore }} von 60</td>
+            </tr>
+            <tr>
+              <td class="font-semibold px-3 py-2">Prozentrang</td>
+              <td class="px-3 py-2">{{ prValue }}</td>
+            </tr>
+            <tr>
+              <td class="font-semibold px-3 py-2">Benötigte Zeit</td>
+              <td class="px-3 py-2">{{ formatTime(props.result.total_time_seconds) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <Button v-if="!showDetails" @click="showDetails = true" class="mb-4 px-4 py-2 rounded-lg font-semibold">
+        Antwort- und Bearbeitungszeit je Aufgabe anzeigen
+      </Button>
+      <Button v-else @click="showDetails = false" class="mb-4 px-4 py-2 rounded-lg font-semibold">
+        Antwort- und Bearbeitungszeit je Aufgabe verbergen
+      </Button>
+
+      <div v-if="showDetails" class="mb-8">
+        <h3 class="font-bold mb-2">Antwort- und Bearbeitungszeit je Aufgabe</h3>
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-sm border rounded-lg shadow">
+            <thead class="bg-muted/40">
+              <tr>
+                <th class="px-2 py-1 text-left font-semibold">#</th>
+                <th class="px-2 py-1 text-left font-semibold">Ihre Auswahl</th>
+                <th class="px-2 py-1 text-left font-semibold">Richtige Antwort(en)</th>
+                <th class="px-2 py-1 text-left font-semibold">Bearbeitungszeit</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(ans, idx) in props.result.answers" :key="idx" :class="ans.is_correct ? 'bg-green-50 dark:bg-green-900/50' : 'bg-red-50 dark:bg-red-900/50'">
+                <td class="px-2 py-1 font-medium text-muted-foreground">{{ ans.number }}</td>
+                <td class="px-2 py-1"><span class="font-mono">{{ ans.user_answer ?? '–' }}</span></td>
+                <td class="px-2 py-1"><span class="font-mono">{{ ans.correct_answers.join(', ') }}</span></td>
+                <td class="px-2 py-1 text-right text-gray-500 dark:text-gray-400 font-mono min-w-[60px]">
+                  {{ formatTime(ans.time_seconds) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="flex flex-row items-center gap-3 mb-8">
+        <span class="font-bold text-base mr-3">RW</span>
+        <template v-for="(score, i) in groupScores" :key="'rwbox' + i">
+          <div class="flex flex-col items-center">
+            <div class="w-10 h-10 border-2 border-black flex items-center justify-center text-base font-bold">
+              {{ score }}
+            </div>
+            <span class="text-xs text-gray-700 dark:text-gray-300 mt-1">U{{ i + 1 }}</span>
+          </div>
+        </template>
+        <div class="flex flex-col items-center ml-6">
+          <div class="w-10 h-10 border-2 border-black flex items-center justify-center text-base font-bold bg-blue-50 dark:bg-blue-900">
+            {{ totalScore }}
+          </div>
+          <span class="text-xs text-gray-700 dark:text-gray-300 mt-1 font-bold">RW GS</span>
+        </div>
+        <div class="flex flex-col items-center ml-6">
+          <div class="w-10 h-10 border-2 border-black flex items-center justify-center text-base font-bold bg-yellow-50 dark:bg-yellow-900">
+            {{ prValue }}
+          </div>
+          <span class="text-xs text-gray-700 dark:text-gray-300 mt-1 font-bold">PR</span>
+        </div>
+      </div>
+      <div style="width: 480px; height: 320px;">
+        <Line :data="chartData" :options="chartOptions" />
+      </div>
+      <div class="w-full flex justify-center mt-6">
+        <div class="w-[400px] h-8 rounded-full bg-gray-200 dark:bg-gray-700 relative overflow-hidden shadow-inner">
+          <div class="h-full bg-red-600 transition-all duration-700 flex items-center justify-center" :style="{ width: (prValue || 0) + '%' }">
+            <span class="opacity-0">.</span>
+          </div>
+          <span class="absolute left-0 w-full h-full flex items-center justify-center text-black font-bold" style="top: 0;" v-if="prValue !== null">
+            {{ prValue }}%
+          </span>
+        </div>
+      </div>
+    </div>
+    <div v-else class="text-center text-gray-600">Kein Ergebnis verfügbar.</div>
+  </div>
+</template>

--- a/resources/views/pdfs/mrt-a-result.blade.php
+++ b/resources/views/pdfs/mrt-a-result.blade.php
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #000; padding: 4px; text-align: center; }
+    </style>
+</head>
+<body>
+    <h1>{{ $test_name }}</h1>
+    <p>Datum: {{ $date }}</p>
+    <p>Teilnehmer: {{ $participant_name }}</p>
+    <p>Dauer: {{ $duration }}</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Gruppe</th>
+                <th>RW</th>
+                <th>SN</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($group_scores as $i => $score)
+            <tr>
+                <td>U{{ $i + 1 }}</td>
+                <td>{{ $score }}</td>
+                <td>{{ $group_stanines[$i] ?? '' }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <p>RW Gesamt: {{ $total_score }} | PR: {{ $prozentrang }}</p>
+</body>
+</html>

--- a/resources/views/pdfs/mrt-a-result.blade.php
+++ b/resources/views/pdfs/mrt-a-result.blade.php
@@ -3,9 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <style>
-        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; }
-        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-        th, td { border: 1px solid #000; padding: 4px; text-align: center; }
+        body { font-family: DejaVu Sans, sans-serif; font-size: 10px; }
+        .answers-table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+        .answers-table th, .answers-table td { border: 1px solid #000; padding: 2px; text-align: center; }
+        .answers-table td.selected { background: #00008b; color: #fff; }
+        .summary-table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        .summary-table th, .summary-table td { border: 1px solid #000; padding: 4px; text-align: center; }
     </style>
 </head>
 <body>
@@ -13,7 +16,30 @@
     <p>Datum: {{ $date }}</p>
     <p>Teilnehmer: {{ $participant_name }}</p>
     <p>Dauer: {{ $duration }}</p>
-    <table>
+
+    <table class="answers-table">
+        <thead>
+            <tr>
+                <th>Nr</th>
+                <th>A</th>
+                <th>B</th>
+                <th>C</th>
+                <th>D</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($answers as $ans)
+            <tr>
+                <td>{{ $ans['number'] }}</td>
+                @foreach(['A','B','C','D'] as $opt)
+                    <td class="{{ strtoupper($ans['user_answer']) === $opt ? 'selected' : '' }}">{{ $opt }}</td>
+                @endforeach
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    <table class="summary-table">
         <thead>
             <tr>
                 <th>Gruppe</th>
@@ -31,6 +57,8 @@
             @endforeach
         </tbody>
     </table>
+
     <p>RW Gesamt: {{ $total_score }} | PR: {{ $prozentrang }}</p>
 </body>
 </html>
+

--- a/resources/views/pdfs/mrt-a-result.blade.php
+++ b/resources/views/pdfs/mrt-a-result.blade.php
@@ -17,6 +17,7 @@
     <p>Teilnehmer: {{ $participant_name }}</p>
     <p>Dauer: {{ $duration }}</p>
 
+    {{-- Antworttabelle --}}
     <table class="answers-table">
         <thead>
             <tr>
@@ -39,6 +40,61 @@
         </tbody>
     </table>
 
+    {{-- Rohwert Boxen und Gesamtwerte --}}
+    <div style="display:flex; align-items:flex-end; gap:8px; margin-top:20px;">
+        <span style="font-weight:bold;">RW</span>
+        @foreach($group_scores as $i => $score)
+            <div style="display:flex; flex-direction:column; align-items:center;">
+                <div style="width:28px;height:28px;border:2px solid #000;display:flex;justify-content:center;align-items:center;font-weight:bold;">{{ $score }}</div>
+                <span style="font-size:8px;margin-top:2px;">U{{ $i + 1 }}</span>
+            </div>
+        @endforeach
+        <div style="display:flex; flex-direction:column; align-items:center; margin-left:12px;">
+            <div style="width:28px;height:28px;border:2px solid #000;background:#e0e7ff;display:flex;justify-content:center;align-items:center;font-weight:bold;">{{ $total_score }}</div>
+            <span style="font-size:8px;margin-top:2px;font-weight:bold;">RW GS</span>
+        </div>
+        <div style="display:flex; flex-direction:column; align-items:center; margin-left:12px;">
+            <div style="width:28px;height:28px;border:2px solid #000;background:#fef08a;display:flex;justify-content:center;align-items:center;font-weight:bold;">{{ $prozentrang }}</div>
+            <span style="font-size:8px;margin-top:2px;font-weight:bold;">PR</span>
+        </div>
+    </div>
+
+    {{-- SN Werte Chart --}}
+    @php
+        $rows = count($group_stanines);
+        $cellW = 30; $cellH = 30;
+        $chartW = $cellW * 9; $chartH = $cellH * $rows;
+        $points = [];
+        foreach($group_stanines as $idx => $sn){
+            $x = ($sn - 0.5) * $cellW;
+            $y = $cellH * $idx + $cellH / 2;
+            $points[] = $x . ',' . $y;
+        }
+    @endphp
+    <svg width="{{ $chartW + 40 }}" height="{{ $chartH + 20 }}" style="margin-top:25px;">
+        <g transform="translate(0,0)">
+            <rect x="{{ $cellW * 3 }}" y="0" width="{{ $cellW * 3 }}" height="{{ $chartH }}" fill="rgba(144,238,144,0.3)" />
+            @for($i=0;$i<=9;$i++)
+                <line x1="{{ $cellW*$i }}" y1="0" x2="{{ $cellW*$i }}" y2="{{ $chartH }}" stroke="#ccc" />
+            @endfor
+            @for($i=0;$i<=$rows;$i++)
+                <line x1="0" y1="{{ $cellH*$i }}" x2="{{ $chartW }}" y2="{{ $cellH*$i }}" stroke="#ccc" />
+            @endfor
+            <polyline points="{{ implode(' ', $points) }}" fill="none" stroke="#1d4ed8" stroke-width="2" />
+            @foreach($points as $pt)
+                @php [$px, $py] = explode(',', $pt); @endphp
+                <circle cx="{{ $px }}" cy="{{ $py }}" r="4" fill="#1d4ed8" />
+            @endforeach
+            @for($i=1;$i<=9;$i++)
+                <text x="{{ ($i-0.5)*$cellW }}" y="{{ $chartH + 12 }}" font-size="10" text-anchor="middle">{{ $i }}</text>
+            @endfor
+            @for($i=0;$i<$rows;$i++)
+                <text x="{{ $chartW + 5 }}" y="{{ $cellH*$i + $cellH/2 }}" font-size="10" dominant-baseline="middle">U{{ $i+1 }}</text>
+            @endfor
+        </g>
+    </svg>
+
+    {{-- Tabelle der Gruppenwerte und Stanine --}}
     <table class="summary-table">
         <thead>
             <tr>
@@ -58,7 +114,7 @@
         </tbody>
     </table>
 
-    <p>RW Gesamt: {{ $total_score }} | PR: {{ $prozentrang }}</p>
+    <p style="margin-top:8px;">RW Gesamt: {{ $total_score }} | PR: {{ $prozentrang }}</p>
 </body>
 </html>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::get('dashboard', [TeacherController::class, 'dashboard'])->name('dashboard');
     Route::get('participant', [ParticipantController::class, 'showProfileForm'])->name('participant');
     Route::get('mrt-a', fn () => Inertia::render('MRT-A'))->name('mrt-a');
+    Route::get('mrt-a/result', [ParticipantController::class, 'mrtAResult'])->name('mrt-a.result');
     Route::get('brt-a', fn () => Inertia::render('BRT-A'))->name('brt-a');
     Route::get('brt-b', fn () => Inertia::render('BRT-B'))->name('brt-b');
     Route::get('fpi-r', fn () => Inertia::render('FPI-R'))->name('fpi-r');


### PR DESCRIPTION
## Summary
- score MRT-A on backend and store results and PDF
- move MRT-A frontend to submit raw answers only

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `php artisan test` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a441587c948329980b5d1405a335f8