### PR TITLE
Add Browsershot PDF generation for test results

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -195,6 +195,9 @@ class ParticipantController extends Controller
           'result_json' => $resultData,
         ]);
 
+        $pdfPath = \App\Services\BrowsershotPdfService::generate($testResult);
+        $testResult->update(['pdf_file_path' => $pdfPath]);
+
         if ($examStep->test->name === 'BRT-A') {
           $pdfPath = \App\Services\BrtAPdfService::generate($testResult);
           if ($pdfPath) {
@@ -245,6 +248,16 @@ class ParticipantController extends Controller
 
         return Inertia::render('Participants/List', [
             'participants' => $participants,
+        ]);
+    }
+
+    public function result(TestResult $testResult)
+    {
+        $testResult->load('assignment.test', 'assignment.participant');
+
+        return Inertia::render('Participants/Result', [
+            'assignment' => $testResult->assignment,
+            'result' => $testResult,
         ]);
     }
 }

--- a/app/Services/BrowsershotPdfService.php
+++ b/app/Services/BrowsershotPdfService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services;
+
+use Spatie\Browsershot\Browsershot;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use App\Models\TestResult;
+
+class BrowsershotPdfService
+{
+    public static function generate(TestResult $result): string
+    {
+        $participant = $result->assignment->participant->name ?? 'participant';
+        $test = $result->assignment->test->name ?? 'test';
+        $fileName = Str::slug($participant, '_') . '_' . Str::slug($test, '_') . '.pdf';
+        $path = "test_results/{$fileName}";
+
+        Storage::makeDirectory('test_results');
+
+        $url = route('participants.result', [$result->id]);
+        Browsershot::url($url)->format('A4')->save(storage_path("app/{$path}"));
+
+        return $path;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "tightenco/ziggy": "^2.4"
+        "tightenco/ziggy": "^2.4",
+        "spatie/browsershot": "^3.63"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "tightenco/ziggy": "^2.4",
-        "spatie/browsershot": "^3.63"
+        "spatie/browsershot": "^5.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/resources/js/pages/Participants/Result.vue
+++ b/resources/js/pages/Participants/Result.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import TestResultViewer from '@/components/TestResultViewer.vue';
+import { ref } from 'vue';
+
+const props = defineProps<{
+    assignment: any;
+    result: any;
+}>();
+
+const resultData = ref(props.result.result_json);
+</script>
+
+<template>
+    <AppLayout>
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <h1 class="text-2xl font-bold mb-4">{{ assignment.test.name }} Result</h1>
+            <TestResultViewer :test="assignment.test" v-model="resultData" />
+        </div>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,6 +51,8 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::put('/test-results/{testResult}', [TestResultController::class, 'update'])->name('test-results.update');
 });
 
+Route::get('/participants/result/{testResult}', [ParticipantController::class, 'result'])->name('participants.result');
+
 Route::get('/login', function () {
     return Inertia::render('auth/Login', [
         'canResetPassword' => Route::has('password.request'),


### PR DESCRIPTION
## Summary
- declare Browsershot dependency
- generate PDF for test results via Browsershot service
- expose participant result route and page for PDF generation

## Testing
- `node --version`
- `chromium --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4facb6d8c83298e54b847d032219f