### PR TITLE
feat: add MRT-A PDF download

### DIFF
--- a/app/Services/MrtAPdfService.php
+++ b/app/Services/MrtAPdfService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TestResult;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Spatie\Browsershot\Browsershot;
+
+class MrtAPdfService
+{
+    /**
+     * Generate a PDF for the given MRT-A test result.
+     */
+    public static function generate(TestResult $result): ?string
+    {
+        if (!class_exists(Browsershot::class)) {
+            return null;
+        }
+
+        $participantName = $result->assignment->participant->name ?? 'participant';
+        $testName = $result->assignment->test->name ?? 'test';
+        $durationSeconds = $result->result_json['total_time_seconds'] ?? 0;
+        $durationFormatted = gmdate('i:s', $durationSeconds);
+
+        $data = [
+            'test_name' => $testName,
+            'date' => now()->format('d.m.Y'),
+            'participant_name' => $participantName,
+            'duration' => $durationFormatted,
+            'results' => $result->result_json,
+        ];
+
+        $html = view('pdfs.mrt-a-result', $data)->render();
+
+        $pdf = Browsershot::html($html)
+            ->format('A4')
+            ->margins(10, 10, 10, 10)
+            ->waitUntilNetworkIdle()
+            ->setDelay(1000)
+            ->showBackground()
+            ->pdf();
+
+        $fileName = Str::slug($participantName, '_') . '_' . Str::slug($testName, '_') . '.pdf';
+        $path = 'test_results/' . $fileName;
+        Storage::put($path, $pdf);
+
+        return $path;
+    }
+}
+

--- a/resources/js/components/MrtAResult.vue
+++ b/resources/js/components/MrtAResult.vue
@@ -197,6 +197,12 @@ const mrtQuestions = [
             </span>
           </div>
         </div>
+        <div class="w-full flex justify-center mt-4">
+          <a :href="route('mrt-a.result.pdf')" target="_blank"
+            class="px-4 py-2 rounded bg-blue-600 text-white font-semibold">
+            PDF herunterladen
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/pdfs/mrt-a-result.blade.php
+++ b/resources/views/pdfs/mrt-a-result.blade.php
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+        h1 { margin-bottom: 0; }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>{{ $test_name }}</h1>
+    <p>Datum: {{ $date }}</p>
+    <p>Teilnehmer: {{ $participant_name }}</p>
+    <p>Dauer: {{ $duration }}</p>
+
+    <div style="width:480px;height:320px;">
+        <canvas id="chart" width="480" height="320"></canvas>
+    </div>
+
+    <script>
+        const data = {
+            labels: ['U1','U2','U3','U4','U5','U6'],
+            datasets: [{
+                label: 'SN',
+                data: @json($results['group_stanines'] ?? []),
+                borderColor: '#1d4ed8',
+                backgroundColor: '#1d4ed8',
+                tension: 0,
+                fill: false,
+                pointRadius: 6,
+                pointBackgroundColor: '#1d4ed8'
+            }]
+        };
+        const options = {
+            responsive: false,
+            plugins: { legend: { display: false }, title: { display: false } },
+            indexAxis: 'y',
+            scales: { x: { min:1, max:9, ticks:{ stepSize:1 } } }
+        };
+        new Chart(document.getElementById('chart'), {
+            type: 'line',
+            data: data,
+            options: options
+        });
+    </script>
+
+    <h2>Werte</h2>
+    <ul>
+        <li>Rohwert: {{ $results['total_score'] ?? '' }}</li>
+        <li>Prozentrang: {{ $results['prozentrang'] ?? '' }}</li>
+    </ul>
+</body>
+</html>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::get('dashboard', [TeacherController::class, 'dashboard'])->name('dashboard');
     Route::get('participant', [ParticipantController::class, 'showProfileForm'])->name('participant');
     Route::get('mrt-a', fn () => Inertia::render('MRT-A'))->name('mrt-a');
+    Route::get('mrt-a/result/pdf', [ParticipantController::class, 'downloadMrtAPdf'])->name('mrt-a.result.pdf');
     Route::get('brt-a', fn () => Inertia::render('BRT-A'))->name('brt-a');
     Route::get('brt-b', fn () => Inertia::render('BRT-B'))->name('brt-b');
     Route::get('fpi-r', fn () => Inertia::render('FPI-R'))->name('fpi-r');


### PR DESCRIPTION
## Summary
- add download button for MRT-A result chart
- generate MRT-A result PDF using Browsershot
- expose endpoint to download MRT-A PDF results

## Testing
- `npm run lint` *(fails: numerous lint errors in existing codebase)*
- `composer test` *(fails: dependencies missing/ext-ldap and GitHub auth required)*

------
https://chatgpt.com/codex/tasks/task_e_68a51174e7e48329a77ec42494205f90