### PR TITLE
feat: enable PDF export for MRT-A results

### DIFF
--- a/resources/js/components/MrtAResult.vue
+++ b/resources/js/components/MrtAResult.vue
@@ -14,6 +14,14 @@ const props = defineProps<{
 }>();
 
 const showDetails = ref(false);
+const chartRef = ref<HTMLDivElement | null>(null);
+const tableRef = ref<HTMLDivElement | null>(null);
+
+defineExpose({
+  chartEl: chartRef,
+  detailsEl: tableRef,
+  showDetails,
+});
 
 function formatTime(sec: number | null): string {
   if (sec === null || isNaN(sec)) return "–";
@@ -123,7 +131,7 @@ const mrtQuestions = [
     </button>
     <div v-if="showDetails">
       <h3 class="font-bold mb-2">Antwort- und Bearbeitungszeit je Aufgabe</h3>
-      <div class="overflow-x-auto">
+      <div ref="tableRef" class="overflow-x-auto">
         <table class="min-w-full text-sm border rounded-lg shadow">
           <thead class="bg-muted/40">
             <tr>
@@ -182,7 +190,7 @@ const mrtQuestions = [
             <span class="text-xs text-gray-700 dark:text-gray-300 mt-1 font-bold">PR</span>
           </div>
         </div>
-        <div style="width: 480px; height: 320px;">
+        <div ref="chartRef" style="width: 480px; height: 320px;">
           <Line :data="chartData" :options="chartOptions" />
         </div>
         <div class="w-full flex justify-center mt-6">

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -2,7 +2,7 @@
 defineOptions({
   inheritAttrs: false,
 });
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 import { Input } from '@/components/ui/input';
 import MrtAResult from '@/components/MrtAResult.vue';
 
@@ -32,6 +32,18 @@ const props = defineProps<{
 const emit = defineEmits(['update:modelValue']);
 
 const local = ref<ResultJson | null>(null);
+const mrtARef = ref<any>(null);
+
+const chartEl = computed(() => mrtARef.value?.chartEl);
+const detailsEl = computed(() => mrtARef.value?.detailsEl);
+const showDetails = computed({
+  get: () => mrtARef.value?.showDetails,
+  set: (v) => {
+    if (mrtARef.value) mrtARef.value.showDetails = v;
+  },
+});
+
+defineExpose({ chartEl, detailsEl, showDetails });
 
 watch(
   () => props.modelValue,
@@ -59,7 +71,7 @@ function formatTime(seconds?: number | null) {
 
 <template>
   <div v-if="local" v-bind="$attrs">
-    <MrtAResult v-if="test.name === 'MRT-A'" :results="local" />
+    <MrtAResult v-if="test.name === 'MRT-A'" :results="local" ref="mrtARef" />
     <template v-else>
       <table class="w-full text-sm border rounded-lg overflow-hidden shadow mb-4">
         <tbody>


### PR DESCRIPTION
## Summary
- expose MRT-A chart and answer table elements for PDF generation
- surface MRT-A result refs through viewer and add export actions in modal
- allow admins to download MRT-A chart or per-question details as A4 PDFs

## Testing
- `npm run format:check` (fails: Code style issues found in 43 files)
- `npm run lint` (fails: 336 errors)
- `./vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a59319cdc0832981fec26899748d48