### PR TITLE
feat: add sex-specific BIT-2 norm tables

### DIFF
--- a/app/Services/Bit2Scorer.php
+++ b/app/Services/Bit2Scorer.php
@@ -19,6 +19,30 @@ class Bit2Scorer
     ];
 
     protected static array $maleNormTable = [
+        ['percentile' => 100, 'TH' => 41, 'GH' => 44, 'TN' => 45, 'EH' => 44, 'LF' => 45, 'KB' => 43, 'VB' => 43, 'LG' => 44, 'SE' => 45],
+        ['percentile' => 95, 'TH' => 35, 'GH' => 38, 'TN' => 42, 'EH' => 37, 'LF' => 41, 'KB' => 36, 'VB' => 32, 'LG' => 37, 'SE' => 40],
+        ['percentile' => 90, 'TH' => 32, 'GH' => 35, 'TN' => 40, 'EH' => 35, 'LF' => 38, 'KB' => 33, 'VB' => 30, 'LG' => 34, 'SE' => 36],
+        ['percentile' => 85, 'TH' => 31, 'GH' => 33, 'TN' => 38, 'EH' => 33, 'LF' => 36, 'KB' => 31, 'VB' => 28, 'LG' => 32, 'SE' => 35],
+        ['percentile' => 80, 'TH' => 30, 'GH' => 32, 'TN' => 37, 'EH' => 32, 'LF' => 34, 'KB' => 29, 'VB' => 27, 'LG' => 29, 'SE' => 33],
+        ['percentile' => 75, 'TH' => 29, 'GH' => 31, 'TN' => 36, 'EH' => 31, 'LF' => 32, 'KB' => 28, 'VB' => 26, 'LG' => 27, 'SE' => 31],
+        ['percentile' => 70, 'TH' => 28, 'GH' => 28, 'TN' => 35, 'EH' => 28, 'LF' => 31, 'KB' => 27, 'VB' => 25, 'LG' => 26, 'SE' => 30],
+        ['percentile' => 65, 'TH' => 26, 'GH' => 27, 'TN' => 34, 'EH' => 27, 'LF' => 29, 'KB' => 26, 'VB' => 24, 'LG' => 24, 'SE' => 28],
+        ['percentile' => 60, 'TH' => 25, 'GH' => 26, 'TN' => 32, 'EH' => 26, 'LF' => 28, 'KB' => 25, 'VB' => 23, 'LG' => 23, 'SE' => 27],
+        ['percentile' => 55, 'TH' => 24, 'GH' => 25, 'TN' => 31, 'EH' => 25, 'LF' => 27, 'KB' => 24, 'VB' => 22, 'LG' => null, 'SE' => 26],
+        ['percentile' => 50, 'TH' => 23, 'GH' => 23, 'TN' => 29, 'EH' => null, 'LF' => 26, 'KB' => 23, 'VB' => null, 'LG' => 22, 'SE' => 24],
+        ['percentile' => 45, 'TH' => 21, 'GH' => 22, 'TN' => 28, 'EH' => 24, 'LF' => 25, 'KB' => 22, 'VB' => 21, 'LG' => 20, 'SE' => 23],
+        ['percentile' => 40, 'TH' => 20, 'GH' => 21, 'TN' => 27, 'EH' => 23, 'LF' => 23, 'KB' => 21, 'VB' => 19, 'LG' => null, 'SE' => 21],
+        ['percentile' => 35, 'TH' => 19, 'GH' => 20, 'TN' => 25, 'EH' => 21, 'LF' => 22, 'KB' => 20, 'VB' => 18, 'LG' => 19, 'SE' => 20],
+        ['percentile' => 30, 'TH' => 18, 'GH' => 19, 'TN' => 23, 'EH' => 20, 'LF' => 20, 'KB' => 19, 'VB' => 16, 'LG' => 18, 'SE' => 19],
+        ['percentile' => 25, 'TH' => 16, 'GH' => 18, 'TN' => 21, 'EH' => 19, 'LF' => 19, 'KB' => 17, 'VB' => 15, 'LG' => 17, 'SE' => 18],
+        ['percentile' => 20, 'TH' => 14, 'GH' => 17, 'TN' => 19, 'EH' => 18, 'LF' => 18, 'KB' => 16, 'VB' => 14, 'LG' => 16, 'SE' => 17],
+        ['percentile' => 15, 'TH' => 13, 'GH' => 15, 'TN' => 18, 'EH' => 17, 'LF' => 17, 'KB' => 15, 'VB' => 12, 'LG' => 15, 'SE' => 15],
+        ['percentile' => 10, 'TH' => 10, 'GH' => 14, 'TN' => 16, 'EH' => 15, 'LF' => 15, 'KB' => 13, 'VB' => 11, 'LG' => 14, 'SE' => 14],
+        ['percentile' => 5,  'TH' => 9,  'GH' => 13, 'TN' => 13, 'EH' => 13, 'LF' => 13, 'KB' => 11, 'VB' => 9,  'LG' => 11, 'SE' => 12],
+        ['percentile' => 0,  'TH' => null, 'GH' => 9,  'TN' => 9,  'EH' => 9,  'LF' => 9,  'KB' => 9,  'VB' => null, 'LG' => 9,  'SE' => 9],
+    ];
+
+    protected static array $femaleNormTable = [
         ['percentile' => 100, 'TH' => 43, 'GH' => 45, 'TN' => 45, 'EH' => 44, 'LF' => 45, 'KB' => 42, 'VB' => 45, 'LG' => 44, 'SE' => 45],
         ['percentile' => 95, 'TH' => 27, 'GH' => 41, 'TN' => 36, 'EH' => 38, 'LF' => 39, 'KB' => 34, 'VB' => 34, 'LG' => 37, 'SE' => 42],
         ['percentile' => 90, 'TH' => 24, 'GH' => 38, 'TN' => 34, 'EH' => 35, 'LF' => 36, 'KB' => 31, 'VB' => 31, 'LG' => 35, 'SE' => 41],
@@ -41,8 +65,6 @@ class Bit2Scorer
         ['percentile' => 5,  'TH' => null, 'GH' => 15, 'TN' => 11, 'EH' => 14, 'LF' => 14, 'KB' => 13, 'VB' => 9,  'LG' => 12, 'SE' => 18],
         ['percentile' => 0,  'TH' => null, 'GH' => 9,  'TN' => 9,  'EH' => 9,  'LF' => 9,  'KB' => 9,  'VB' => null, 'LG' => 9,  'SE' => 10],
     ];
-
-    protected static array $femaleNormTable = self::$maleNormTable;
 
     protected static function normTable(?string $sex): array
     {

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -111,7 +111,6 @@ const bit2NormTables: Record<'m' | 'f', NormRow[]> = {
         { percentile: '>0', TH: null, GH: 9, TN: 9, EH: 9, LF: 9, KB: 9, VB: null, LG: 9, SE: 10 },
     ],
 };
-bit2NormTables.f = bit2NormTables.m;
 
 const normTable = computed(() => bit2NormTables[props.participantProfile?.sex === 'f' ? 'f' : 'm']);
 


### PR DESCRIPTION
## Summary
- add male and female BIT-2 percentile tables to scorer
- keep frontend female norm table separate from male data

## Testing
- `php -l app/Services/Bit2Scorer.php`
- `composer test` *(fails: Failed to open stream: No such file or directory)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: requires GitHub OAuth token)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: multiple lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c1823a6c8329bd75c534127471c8