### PR TITLE
feat: add LMT result view

### DIFF
--- a/resources/js/components/LmtResult.vue
+++ b/resources/js/components/LmtResult.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+const { results } = defineProps<{ results: any }>()
+
+function formatTime(sec: number | null | undefined): string {
+  if (sec == null || isNaN(sec)) return '–'
+  const s = Number(sec)
+  if (s < 60) return `${s} s`
+  const m = Math.floor(s / 60)
+  const rest = s % 60
+  return rest ? `${m}m ${rest}s` : `${m}m`
+}
+
+const scales = [
+  { key: 'L1', label: 'L1' },
+  { key: 'L2', label: 'L2' },
+  { key: 'F-', label: 'F−' },
+  { key: 'F+', label: 'F⁺' },
+]
+</script>
+
+<template>
+  <div class="p-6 bg-background border rounded-lg">
+    <h2 class="text-xl font-semibold mb-4">Test abgeschlossen!</h2>
+    <div class="mb-6 w-full max-w-md">
+      <table class="w-full text-sm border rounded-lg overflow-hidden shadow">
+        <tbody>
+          <tr class="bg-muted/40">
+            <td class="font-semibold px-3 py-2 w-1/2">Gesamtdauer</td>
+            <td class="px-3 py-2">{{ formatTime(results.total_time_seconds) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="overflow-x-auto mb-6">
+      <table class="min-w-full text-sm border rounded shadow">
+        <thead class="bg-muted/40">
+          <tr>
+            <th class="p-2 text-left">Skala</th>
+            <th class="p-2 text-left">Rohwert</th>
+            <th class="p-2 text-left">T-Wert</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="scale in scales" :key="scale.key" class="border-t">
+            <td class="p-2 font-semibold">{{ scale.label }}</td>
+            <td class="p-2">{{ results.group_scores?.[scale.key] ?? '–' }}</td>
+            <td class="p-2">{{ results.group_t_values?.[scale.key] ?? '–' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div v-if="results.answers" class="overflow-x-auto">
+      <table class="min-w-full text-sm border rounded shadow">
+        <thead class="bg-muted/40">
+          <tr>
+            <th class="p-2 text-left">#</th>
+            <th class="p-2 text-left">Antwort</th>
+            <th class="p-2 text-left">Gruppe</th>
+            <th class="p-2 text-left">Punkte</th>
+            <th class="p-2 text-left">Zeit</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(ans, idx) in results.answers" :key="idx" class="border-t">
+            <td class="p-2">{{ ans.number }}</td>
+            <td class="p-2">{{ ans.selected_category ?? '–' }}</td>
+            <td class="p-2">{{ ans.selected_group ?? '–' }}</td>
+            <td class="p-2">{{ ans.points ?? '–' }}</td>
+            <td class="p-2">{{ formatTime(ans.time_seconds) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+

--- a/resources/js/components/LmtResult.vue
+++ b/resources/js/components/LmtResult.vue
@@ -36,43 +36,68 @@ const scales = [
       <table class="min-w-full text-sm border rounded shadow">
         <thead class="bg-muted/40">
           <tr>
-            <th class="p-2 text-left">Skala</th>
-            <th class="p-2 text-left">Rohwert</th>
-            <th class="p-2 text-left">T-Wert</th>
+            <th class="p-2 text-left"></th>
+            <th
+              v-for="scale in scales"
+              :key="scale.key"
+              class="p-2 text-left"
+            >
+              {{ scale.label }}
+            </th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="scale in scales" :key="scale.key" class="border-t">
-            <td class="p-2 font-semibold">{{ scale.label }}</td>
-            <td class="p-2">{{ results.group_scores?.[scale.key] ?? '–' }}</td>
-            <td class="p-2">{{ results.group_t_values?.[scale.key] ?? '–' }}</td>
+          <tr class="border-t">
+            <td class="p-2 font-semibold">Rohwert</td>
+            <td
+              v-for="scale in scales"
+              :key="scale.key"
+              class="p-2"
+            >
+              {{ results.group_scores?.[scale.key] ?? '–' }}
+            </td>
+          </tr>
+          <tr class="border-t">
+            <td class="p-2 font-semibold">T-Wert</td>
+            <td
+              v-for="scale in scales"
+              :key="scale.key"
+              class="p-2"
+            >
+              {{ results.group_t_values?.[scale.key] ?? '–' }}
+            </td>
           </tr>
         </tbody>
       </table>
     </div>
 
-    <div v-if="results.answers" class="overflow-x-auto">
-      <table class="min-w-full text-sm border rounded shadow">
-        <thead class="bg-muted/40">
-          <tr>
-            <th class="p-2 text-left">#</th>
-            <th class="p-2 text-left">Antwort</th>
-            <th class="p-2 text-left">Gruppe</th>
-            <th class="p-2 text-left">Punkte</th>
-            <th class="p-2 text-left">Zeit</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(ans, idx) in results.answers" :key="idx" class="border-t">
-            <td class="p-2">{{ ans.number }}</td>
-            <td class="p-2">{{ ans.selected_category ?? '–' }}</td>
-            <td class="p-2">{{ ans.selected_group ?? '–' }}</td>
-            <td class="p-2">{{ ans.points ?? '–' }}</td>
-            <td class="p-2">{{ formatTime(ans.time_seconds) }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <details v-if="results.answers" class="mb-6">
+      <summary class="cursor-pointer select-none px-2 py-1 bg-muted/40 rounded">
+        Antworten
+      </summary>
+      <div class="overflow-x-auto mt-2">
+        <table class="min-w-full text-sm border rounded shadow">
+          <thead class="bg-muted/40">
+            <tr>
+              <th class="p-2 text-left">#</th>
+              <th class="p-2 text-left">Antwort</th>
+              <th class="p-2 text-left">Gruppe</th>
+              <th class="p-2 text-left">Punkte</th>
+              <th class="p-2 text-left">Zeit</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(ans, idx) in results.answers" :key="idx" class="border-t">
+              <td class="p-2">{{ ans.number }}</td>
+              <td class="p-2">{{ ans.selected_category ?? '–' }}</td>
+              <td class="p-2">{{ ans.selected_group ?? '–' }}</td>
+              <td class="p-2">{{ ans.points ?? '–' }}</td>
+              <td class="p-2">{{ formatTime(ans.time_seconds) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </details>
   </div>
 </template>
 

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -3,6 +3,7 @@ defineOptions({
     inheritAttrs: false,
 });
 import MrtAResult from '@/components/MrtAResult.vue';
+import LmtResult from '@/components/LmtResult.vue';
 import { Input } from '@/components/ui/input';
 import { computed, ref, watch } from 'vue';
 const bit2Groups = ['TH', 'GH', 'TN', 'EH', 'LF', 'KB', 'VB', 'LG', 'SE'];
@@ -138,6 +139,7 @@ const highlighted = computed(() => {
 <template>
     <div v-if="local" v-bind="$attrs">
         <MrtAResult v-if="test.name === 'MRT-A'" :results="local" />
+        <LmtResult v-else-if="test.name === 'LMT'" :results="local" />
         <div v-else-if="test.name === 'BIT-2'" class="overflow-x-auto">
             <table class="mb-4 w-full overflow-hidden rounded-lg border text-sm shadow">
                 <thead class="bg-muted/40 dark:bg-gray-700">


### PR DESCRIPTION
## Summary
- add LMT result viewer component for L1, L2, F-, F+ metrics
- show LMT results in TestResultViewer using new table-based layout

## Testing
- `npm run lint` *(fails: 26 errors)*
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f07833a083299e1f4faa3d29f309