### PR TITLE
feat: display FPI‑R results in participant modal

### DIFF
--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -4,6 +4,7 @@ defineOptions({
 });
 import MrtAResult from '@/components/MrtAResult.vue';
 import LmtResult from '@/components/LmtResult.vue';
+import FpiResult from '@/pages/Scores/FPI/FPIResult.vue';
 import { Input } from '@/components/ui/input';
 import { computed, ref, watch } from 'vue';
 const bit2Groups = ['TH', 'GH', 'TN', 'EH', 'LF', 'KB', 'VB', 'LG', 'SE'];
@@ -134,12 +135,33 @@ const highlighted = computed(() => {
     }
     return map;
 });
+
+const fpiStanines = computed(() => {
+    if (!local.value) return [];
+    if (Array.isArray(local.value.stanines)) return local.value.stanines;
+    if (local.value.category_stanines) {
+        const keys = ['LEB', 'SOZ', 'LEI', 'GEH', 'ERR', 'AGGR', 'BEAN', 'KORP', 'GES', 'OFF', 'EXTR', 'EMOT'];
+        return keys.map((k) => local.value?.category_stanines?.[k] ?? null);
+    }
+    return [];
+});
+
+const fpiRohwerte = computed(() => {
+    if (!local.value) return [];
+    if (Array.isArray(local.value.rohwerte)) return local.value.rohwerte;
+    if (local.value.category_scores) {
+        const keys: (string | number)[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 'E', 'N'];
+        return keys.map((k) => local.value?.category_scores?.[k] ?? null);
+    }
+    return [];
+});
 </script>
 
 <template>
     <div v-if="local" v-bind="$attrs">
         <MrtAResult v-if="test.name === 'MRT-A'" :results="local" />
         <LmtResult v-else-if="test.name === 'LMT'" :results="local" />
+        <FpiResult v-else-if="test.name === 'FPI-R'" :stanines="fpiStanines" :rohwerte="fpiRohwerte" />
         <div v-else-if="test.name === 'BIT-2'" class="overflow-x-auto">
             <table class="mb-4 w-full overflow-hidden rounded-lg border text-sm shadow">
                 <thead class="bg-muted/40 dark:bg-gray-700">

--- a/resources/js/pages/Scores/FPI/FPIResult.vue
+++ b/resources/js/pages/Scores/FPI/FPIResult.vue
@@ -40,14 +40,22 @@ const getCatNum = (index: number): string => {
   return 'N';
 };
 
-const staninePoints = computed(() => {
-  return props.stanines.map((s, idx) => {
-    if (!s || s < 1 || s > 9) return null;
-    const x = (9 - s) * cellWidth + cellWidth / 2;
-    const y = idx * rowHeight + rowHeight / 2;
-    return `${x},${y}`;
-  }).filter(Boolean).join(' ');
+interface Point { x: number; y: number }
+
+const stanineCoords = computed<Point[]>(() => {
+  return props.stanines
+    .map((s, idx) => {
+      if (!s || s < 1 || s > 9) return null;
+      const x = (9 - s) * cellWidth + cellWidth / 2;
+      const y = idx * rowHeight + rowHeight / 2;
+      return { x, y } as Point;
+    })
+    .filter((p): p is Point => p !== null);
 });
+
+const staninePoints = computed(() =>
+  stanineCoords.value.map(({ x, y }) => `${x},${y}`).join(' '),
+);
 </script>
 
 <template>
@@ -110,6 +118,16 @@ const staninePoints = computed(() => {
         ></div>
         <svg :width="gridWidth" :height="gridHeight" class="polyline-svg">
           <polyline :points="staninePoints" fill="none" stroke="black" stroke-width="1.5" />
+          <circle
+            v-for="(pt, idx) in stanineCoords"
+            :key="idx"
+            :cx="pt.x"
+            :cy="pt.y"
+            r="4"
+            fill="white"
+            stroke="black"
+            stroke-width="1.5"
+          />
         </svg>
         <div
           class="average-box"

--- a/resources/js/pages/Scores/FPI/FPIResult.vue
+++ b/resources/js/pages/Scores/FPI/FPIResult.vue
@@ -31,6 +31,8 @@ const cellWidth = 37.5;
 const rowHeight = 65; // Generous height for clear spacing
 const gridWidth = cellWidth * 9;
 const gridHeight = rowHeight * 12;
+const headerHeight = 48;
+const graphOffset = 85 + 230;
 
 const getCatNum = (index: number): string => {
   if (index < 10) return (index + 1).toString();
@@ -91,27 +93,41 @@ const staninePoints = computed(() => {
       </template>
 
       <!-- Graph Overlays -->
-      <div class="graph-overlay-container">
-          <!-- CORRECTED v-for loop with :key -->
-          <div
-            v-for="(pos, index) in [2.5, 6.5]"
-            :key="'blue-line-' + index"
-            class="blue-line"
-            :style="{ left: `${cellWidth * pos}px` }"
-          ></div>
-          <svg :width="gridWidth" :height="gridHeight" class="polyline-svg">
-              <polyline :points="staninePoints" fill="none" stroke="black" stroke-width="1.5"/>
-          </svg>
-          <div class="average-box" :style="{ top: 0, height: `${rowHeight * 10}px`, left: `${cellWidth * 3}px`, width: `${cellWidth * 3}px` }">
-             <div class="percent-label top">
-                54% <div class="percent-connector"></div>
-             </div>
+      <div
+        class="graph-overlay-container"
+        :style="{
+          top: `${headerHeight}px`,
+          left: `${graphOffset}px`,
+          width: `${gridWidth}px`,
+          height: `${gridHeight}px`,
+        }"
+      >
+        <div
+          v-for="(pos, index) in [2.5, 6.5]"
+          :key="`blue-line-${index}`"
+          class="blue-line"
+          :style="{ left: `${cellWidth * pos}px` }"
+        ></div>
+        <svg :width="gridWidth" :height="gridHeight" class="polyline-svg">
+          <polyline :points="staninePoints" fill="none" stroke="black" stroke-width="1.5" />
+        </svg>
+        <div
+          class="average-box"
+          :style="{ top: 0, height: `${rowHeight * 10}px`, left: `${cellWidth * 3}px`, width: `${cellWidth * 3}px` }
+          "
+        >
+          <div class="percent-label top">
+            54%
+            <div class="percent-connector"></div>
           </div>
-          <div class="average-box" :style="{ top: `${rowHeight * 10}px`, height: `${rowHeight * 2}px`, left: `${cellWidth * 3}px`, width: `${cellWidth * 3}px` }">
-             <div class="percent-label bottom">
-                54%
-             </div>
-          </div>
+        </div>
+        <div
+          class="average-box"
+          :style="{ top: `${rowHeight * 10}px`, height: `${rowHeight * 2}px`, left: `${cellWidth * 3}px`, width: `${cellWidth * 3}px` }
+          "
+        >
+          <div class="percent-label bottom">54%</div>
+        </div>
       </div>
 
       <!-- Footer Row -->
@@ -201,8 +217,8 @@ const staninePoints = computed(() => {
 .graph-dots { display: flex; justify-content: space-around; align-items: center; height: 100%; width: 100%;}
 .dot { width: 4px; height: 4px; background-color: #000; border-radius: 50%; }
 .graph-overlay-container {
-  grid-column: 3 / 4; grid-row: 2 / 14;
-  position: absolute; pointer-events: none;
+  position: absolute;
+  pointer-events: none;
 }
 .blue-line {
   position: absolute;

--- a/resources/js/pages/Scores/FPI/FPIResult.vue
+++ b/resources/js/pages/Scores/FPI/FPIResult.vue
@@ -42,19 +42,25 @@ const getCatNum = (index: number): string => {
 
 interface Point { x: number; y: number }
 
-const stanineCoords = computed<Point[]>(() => {
-  return props.stanines
+function stanineX(idx: number) {
+  return cellWidth * idx + cellWidth / 2;
+}
+
+function rowY(idx: number) {
+  return rowHeight * idx + rowHeight / 2;
+}
+
+const stanineCoords = computed<Point[]>(() =>
+  props.stanines
     .map((s, idx) => {
       if (!s || s < 1 || s > 9) return null;
-      const x = (9 - s) * cellWidth + cellWidth / 2;
-      const y = idx * rowHeight + rowHeight / 2;
-      return { x, y } as Point;
+      return { x: stanineX(s - 1), y: rowY(idx) } as Point;
     })
-    .filter((p): p is Point => p !== null);
-});
+    .filter((p): p is Point => p !== null),
+);
 
 const staninePoints = computed(() =>
-  stanineCoords.value.map(({ x, y }) => `${x},${y}`).join(' '),
+  stanineCoords.value.map((pt) => `${pt.x},${pt.y}`).join(' '),
 );
 </script>
 


### PR DESCRIPTION
## Summary
- show FPI‑R result sheet in participant result modal
- derive FPI‑R stanines and raw scores from category data so graph renders

## Testing
- `npm run lint` *(fails: unused variables in unrelated files)*
- `npx eslint resources/js/components/TestResultViewer.vue`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fd62f0508329b13065b63d81f2f5