### PR TITLE
feat: add exam status endpoint and polling

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -120,6 +120,24 @@ class ParticipantController extends Controller
     ]);
   }
 
+  public function examStatus()
+  {
+    $user = Auth::user();
+    $examParticipant = ExamParticipant::where('participant_id', $user->id)->first();
+
+    if (!$examParticipant) {
+      return response()->json(['status' => 'no_exam']);
+    }
+
+    $exam = Exam::find($examParticipant->exam_id);
+
+    if (!$exam) {
+      return response()->json(['status' => 'no_exam']);
+    }
+
+    return response()->json(['status' => $exam->status]);
+  }
+
   public function noExam()
   {
     return Inertia::render('Exams/NoExam');

--- a/resources/js/pages/Exams/NoExam.vue
+++ b/resources/js/pages/Exams/NoExam.vue
@@ -2,10 +2,36 @@
 import { Head, Link, router } from '@inertiajs/vue3'
 import { LogOut } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
+import axios from 'axios'
+import { onMounted, onUnmounted } from 'vue'
 
 const handleLogout = () => {
   router.flushAll()
 }
+
+let polling: any = null
+
+const checkExamStatus = async () => {
+  try {
+    const response = await axios.get(route('api.exam-status'))
+    if (response.data?.status === 'in_progress') {
+      router.get(route('my-exam'))
+    }
+  } catch (error) {
+    console.error('Error checking exam status:', error)
+  }
+}
+
+onMounted(() => {
+  polling = setInterval(checkExamStatus, 5000)
+  checkExamStatus()
+})
+
+onUnmounted(() => {
+  if (polling) {
+    clearInterval(polling)
+  }
+})
 </script>
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/exams/store-with-participants', [ExamController::class, 'storeWithParticipants'])->name('exams.storeWithParticipants');
     Route::put('/exams/{exam}/steps', [ExamController::class, 'updateSteps'])->name('exams.updateSteps');
     Route::get('/api/active-exams', [ExamController::class, 'getActiveExams'])->name('api.active-exams');
+    Route::get('/api/exam/status', [ParticipantController::class, 'examStatus'])->name('api.exam-status');
     Route::get('/participants', [ParticipantController::class, 'list'])->name('participants.list');
     Route::put('/test-results/{testResult}', [TestResultController::class, 'update'])->name('test-results.update');
 });


### PR DESCRIPTION
## Summary
- add API endpoint to expose authenticated participant exam status
- poll for exam status in NoExam page to redirect once exam starts

## Testing
- `npm run lint` *(fails: unused vars in existing files)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: 403 while downloading packages)*
- `php -l app/Http/Controllers/ParticipantController.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa63f317e483299d4af9ee78feb439