### PR TITLE
feat: guard exam start until participants ready

### DIFF
--- a/app/Http/Controllers/ExamController.php
+++ b/app/Http/Controllers/ExamController.php
@@ -169,6 +169,16 @@ class ExamController extends Controller
       return back(303)->with('error', 'Exam has no steps.');
     }
 
+    $incompleteParticipants = $exam->participants()
+      ->where('status', '!=', 'waiting')
+      ->with('user')
+      ->get();
+
+    if ($incompleteParticipants->isNotEmpty()) {
+      $names = $incompleteParticipants->map(fn($p) => $p->user->name)->toArray();
+      return response()->json(['participants' => $names], 422);
+    }
+
     $firstStep = $exam->steps()->orderBy('step_order')->first();
 
     $exam->update([

--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -69,11 +69,14 @@ class ParticipantController extends Controller
 
     $examParticipant = ExamParticipant::where('participant_id', $user->id)->first();
     if ($examParticipant) {
+      $examParticipant->update(['status' => 'waiting']);
+
       $exam = Exam::find($examParticipant->exam_id);
       if ($exam && $exam->status === 'in_progress') {
         return redirect()->route('my-exam');
       }
     }
+
     return redirect()->route('participant.no-exam');
   }
 


### PR DESCRIPTION
## Summary
- mark participant as waiting once profile is saved
- block exam start until all participants are waiting and report incomplete users
- show not-ready participants in exam status view and disable start button

## Testing
- `npm run lint` *(fails: 'selectedParticipant' is assigned a value but never used...)*
- `composer install --no-interaction --ignore-platform-req=ext-ldap` *(fails: Failed to clone https://github.com/pestphp/pest-plugin.git via https, ssh protocols, aborting.)*


------
https://chatgpt.com/codex/tasks/task_e_68aa64274420832989f06a53c7981b06