### PR TITLE
Include correct answers in BRT test results

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -174,10 +174,12 @@ class ParticipantController extends Controller
           $answers = $results['answers'] ?? [];
           $times = $results['question_times'] ?? [];
           $resultData = \App\Services\BrtAScorer::score($answers, $times);
+          $resultData = \App\Services\BrtAScorer::addCorrectAnswers($resultData);
         } elseif ($examStep->test->name === 'BRT-B') {
           $answers = $results['answers'] ?? [];
           $times = $results['question_times'] ?? [];
           $resultData = \App\Services\BrtBScorer::score($answers, $times);
+          $resultData = \App\Services\BrtBScorer::addCorrectAnswers($resultData);
         } elseif ($examStep->test->name === 'FPI-R') {
           $answers = $results['answers'] ?? [];
           $totalTime = $results['total_time_seconds'] ?? null;

--- a/app/Services/BrtAScorer.php
+++ b/app/Services/BrtAScorer.php
@@ -66,6 +66,16 @@ class BrtAScorer
         ];
     }
 
+    public static function addCorrectAnswers(array $result): array
+    {
+        foreach (self::$questions as $index => $question) {
+            if (isset($result['answers'][$index])) {
+                $result['answers'][$index]['correct_answers'] = $question['answers'];
+            }
+        }
+        return $result;
+    }
+
     protected static function getTwertFromPR(float $pr): float
     {
         $best = self::$prToTwert[0];

--- a/app/Services/BrtBScorer.php
+++ b/app/Services/BrtBScorer.php
@@ -91,6 +91,16 @@ class BrtBScorer
     ];
   }
 
+  public static function addCorrectAnswers(array $result): array
+  {
+    foreach (self::$questions as $index => $question) {
+      if (isset($result['answers'][$index])) {
+        $result['answers'][$index]['correct_answers'] = $question['answers'];
+      }
+    }
+    return $result;
+  }
+
   protected static function getTwertFromPR(float $pr): float
   {
     $best = self::$prToTwert[0];

--- a/tests/Unit/BrtScorerTest.php
+++ b/tests/Unit/BrtScorerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\BrtAScorer;
+use App\Services\BrtBScorer;
+use Tests\TestCase;
+
+class BrtScorerTest extends TestCase
+{
+    public function test_brt_a_adds_correct_answers(): void
+    {
+        $result = BrtAScorer::score([], []);
+        $result = BrtAScorer::addCorrectAnswers($result);
+
+        $this->assertArrayHasKey('answers', $result);
+        $this->assertArrayHasKey('correct_answers', $result['answers'][0]);
+        $this->assertEquals(['77420'], $result['answers'][0]['correct_answers']);
+    }
+
+    public function test_brt_b_adds_correct_answers(): void
+    {
+        $result = BrtBScorer::score([], []);
+        $result = BrtBScorer::addCorrectAnswers($result);
+
+        $this->assertArrayHasKey('answers', $result);
+        $this->assertArrayHasKey('correct_answers', $result['answers'][0]);
+        $this->assertEquals(['277420'], $result['answers'][0]['correct_answers']);
+    }
+}


### PR DESCRIPTION
## Summary
- Append correct solutions to BRT-A and BRT-B results when saving test data
- Add helper methods to attach solutions for BRT scorers
- Update unit tests for new correct-answer injection

## Testing
- `composer test` *(fails: require(/workspace/EPT/vendor/autoload.php): Failed to open stream: No such file or directory)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: CONNECT tunnel failed, response 403)*
- `npm run lint` *(fails: 23 errors, e.g., unused variables in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3f9012d08329b34b15dadf55774f