### PR TITLE
Enable PDF downloads for MRT test results

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -211,6 +211,12 @@ class ParticipantController extends Controller
             $testResult->update(['pdf_file_path' => $pdfPath]);
           }
         }
+        if (in_array($examStep->test->name, ['MRT-A', 'MRT-B'])) {
+          $pdfPath = \App\Services\MrtPdfService::generate($testResult);
+          if ($pdfPath) {
+            $testResult->update(['pdf_file_path' => $pdfPath]);
+          }
+        }
         if ($examStep->test->name === 'FPI-R') {
           $pdfPath = \App\Services\FpiRPdfService::generate($testResult);
           if ($pdfPath) {

--- a/app/Services/MrtPdfService.php
+++ b/app/Services/MrtPdfService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TestResult;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class MrtPdfService
+{
+    public static function generate(TestResult $result): ?string
+    {
+        if (!class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
+            return null;
+        }
+
+        $assignment = $result->assignment;
+        $participantName = $assignment->participant->name ?? 'participant';
+        $testName = $assignment->test->name ?? 'test';
+        $durationSeconds = $result->result_json['total_time_seconds'] ?? 0;
+        $durationFormatted = gmdate('i:s', $durationSeconds);
+
+        $data = [
+            'test_name' => $testName,
+            'date' => now()->format('d.m.Y'),
+            'participant_name' => $participantName,
+            'duration' => $durationFormatted,
+            'total_score' => $result->result_json['total_score'] ?? null,
+            'prozentrang' => $result->result_json['prozentrang'] ?? null,
+            'group_scores' => $result->result_json['group_scores'] ?? [],
+            'group_stanines' => $result->result_json['group_stanines'] ?? [],
+        ];
+
+        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('pdfs.mrt-result', $data)->setPaper('a4');
+        $fileName = Str::slug($participantName, '_') . '_' . Str::slug($testName, '_') . '.pdf';
+        $path = 'test_results/' . $fileName;
+        Storage::put($path, $pdf->output());
+        return $path;
+    }
+}

--- a/resources/views/pdfs/mrt-result.blade.php
+++ b/resources/views/pdfs/mrt-result.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #000; padding: 8px; text-align: left; }
+    </style>
+</head>
+<body>
+    <h1>{{ $test_name }}</h1>
+    <p>Datum: {{ $date }}</p>
+    <p>Teilnehmer: {{ $participant_name }}</p>
+    <p>Dauer: {{ $duration }}</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Gruppe</th>
+                <th>Rohwert</th>
+                <th>Stanine</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($group_scores as $idx => $score)
+            <tr>
+                <td>{{ 'U' . ($idx + 1) }}</td>
+                <td>{{ $score }}</td>
+                <td>{{ $group_stanines[$idx] ?? '' }}</td>
+            </tr>
+            @endforeach
+            <tr>
+                <td><strong>Gesamt</strong></td>
+                <td>{{ $total_score }}</td>
+                <td>PR: {{ $prozentrang }}</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add service to render MRT results to PDF via DomPDF
- store generated PDF path for MRT tests and expose it to result modal

## Testing
- `npm run lint`
- `composer test` *(fails: Failed to open stream: No such file or directory in artisan on line 10)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: requires GitHub token; CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae331ffd888329b5fb9a777044e349