### PR TITLE
Add LMT PDF generation

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -211,6 +211,12 @@ class ParticipantController extends Controller
             $testResult->update(['pdf_file_path' => $pdfPath]);
           }
         }
+        if ($examStep->test->name === 'LMT') {
+          $pdfPath = \App\Services\LmtPdfService::generate($testResult);
+          if ($pdfPath) {
+            $testResult->update(['pdf_file_path' => $pdfPath]);
+          }
+        }
         if ($examStep->test->name === 'FPI-R') {
           $pdfPath = \App\Services\FpiRPdfService::generate($testResult);
           if ($pdfPath) {

--- a/app/Services/LmtPdfService.php
+++ b/app/Services/LmtPdfService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TestResult;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class LmtPdfService
+{
+    public static function generate(TestResult $result): ?string
+    {
+        if (!class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
+            return null;
+        }
+
+        $assignment = $result->assignment;
+        $participant = $assignment->participant;
+        $participantName = $participant->name ?? 'participant';
+        $testName = $assignment->test->name ?? 'test';
+        $durationSeconds = $result->result_json['total_time_seconds'] ?? 0;
+        $durationFormatted = gmdate('i:s', $durationSeconds);
+
+        $data = [
+            'test_name' => $testName,
+            'date' => now()->format('d.m.Y'),
+            'participant_name' => $participantName,
+            'duration' => $durationFormatted,
+            'group_scores' => $result->result_json['group_scores'] ?? [],
+            'group_t_values' => $result->result_json['group_t_values'] ?? [],
+        ];
+
+        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('pdfs.lmt-result', $data)->setPaper('a4');
+        $fileName = Str::slug($participantName, '_') . '_' . Str::slug($testName, '_') . '.pdf';
+        $path = 'test_results/' . $fileName;
+        Storage::put($path, $pdf->output());
+
+        return $path;
+    }
+}

--- a/resources/views/pdfs/lmt-result.blade.php
+++ b/resources/views/pdfs/lmt-result.blade.php
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #000; padding: 8px; text-align: left; }
+    </style>
+</head>
+<body>
+    <h1>{{ $test_name }}</h1>
+    <p>Datum: {{ $date }}</p>
+    <p>Teilnehmer: {{ $participant_name }}</p>
+    <p>Dauer: {{ $duration }}</p>
+    <table>
+        <thead>
+            <tr>
+                <th></th>
+                <th>L1</th>
+                <th>L2</th>
+                <th>F-</th>
+                <th>F+</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Rohwert</td>
+                <td>{{ $group_scores['L1'] ?? '–' }}</td>
+                <td>{{ $group_scores['L2'] ?? '–' }}</td>
+                <td>{{ $group_scores['F-'] ?? '–' }}</td>
+                <td>{{ $group_scores['F+'] ?? '–' }}</td>
+            </tr>
+            <tr>
+                <td>T-Wert</td>
+                <td>{{ $group_t_values['L1'] ?? '–' }}</td>
+                <td>{{ $group_t_values['L2'] ?? '–' }}</td>
+                <td>{{ $group_t_values['F-'] ?? '–' }}</td>
+                <td>{{ $group_t_values['F+'] ?? '–' }}</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Generate LMT result PDFs via new LmtPdfService and Blade template
- Wire LMT PDF creation into participant completion flow

## Testing
- `php artisan test` *(fails: require vendor autoload.php)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_e_68ae37b63d9c8329ba0d645a7bb7173c