### PR TITLE
feat: add server-side MRT PDF generation with chart image

### DIFF
--- a/app/Services/MrtPdfService.php
+++ b/app/Services/MrtPdfService.php
@@ -8,19 +8,15 @@ use Illuminate\Support\Str;
 
 class MrtPdfService
 {
-    public static function generate(TestResult $result): ?string
+    protected static function buildData(TestResult $result, ?string $chart = null): array
     {
-        if (!class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
-            return null;
-        }
-
         $assignment = $result->assignment;
         $participantName = $assignment->participant->name ?? 'participant';
         $testName = $assignment->test->name ?? 'test';
         $durationSeconds = $result->result_json['total_time_seconds'] ?? 0;
         $durationFormatted = gmdate('i:s', $durationSeconds);
 
-        $data = [
+        return [
             'test_name' => $testName,
             'date' => now()->format('d.m.Y'),
             'participant_name' => $participantName,
@@ -29,12 +25,34 @@ class MrtPdfService
             'prozentrang' => $result->result_json['prozentrang'] ?? null,
             'group_scores' => $result->result_json['group_scores'] ?? [],
             'group_stanines' => $result->result_json['group_stanines'] ?? [],
+            'chart' => $chart,
         ];
+    }
 
+    public static function generate(TestResult $result): ?string
+    {
+        if (!class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
+            return null;
+        }
+
+        $data = self::buildData($result);
         $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('pdfs.mrt-result', $data)->setPaper('a4');
-        $fileName = Str::slug($participantName, '_') . '_' . Str::slug($testName, '_') . '.pdf';
+        $fileName = Str::slug($data['participant_name'], '_') . '_' . Str::slug($data['test_name'], '_') . '.pdf';
         $path = 'test_results/' . $fileName;
         Storage::put($path, $pdf->output());
         return $path;
+    }
+
+    public static function download(TestResult $result, string $chart)
+    {
+        if (!class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
+            return null;
+        }
+
+        $data = self::buildData($result, $chart);
+        $fileName = Str::slug($data['participant_name'], '_') . '_' . Str::slug($data['test_name'], '_') . '.pdf';
+        return \Barryvdh\DomPDF\Facade\Pdf::loadView('pdfs.mrt-result', $data)
+            ->setPaper('a4')
+            ->download($fileName);
     }
 }

--- a/resources/views/pdfs/mrt-result.blade.php
+++ b/resources/views/pdfs/mrt-result.blade.php
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <style>
         body { font-family: DejaVu Sans, sans-serif; }
+        .chart { text-align: center; margin: 40px 0; }
         table { width: 100%; border-collapse: collapse; margin-top: 20px; }
         th, td { border: 1px solid #000; padding: 8px; text-align: left; }
     </style>
@@ -13,6 +14,11 @@
     <p>Datum: {{ $date }}</p>
     <p>Teilnehmer: {{ $participant_name }}</p>
     <p>Dauer: {{ $duration }}</p>
+    @if($chart)
+    <div class="chart">
+        <img src="{{ $chart }}" alt="MRT chart" style="max-width: 400px; height: auto;">
+    </div>
+    @endif
     <table>
         <thead>
             <tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,6 +52,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::get('/participants', [ParticipantController::class, 'list'])->name('participants.list');
     Route::put('/test-results/{testResult}', [TestResultController::class, 'update'])->name('test-results.update');
     Route::get('/test-results/{testResult}/download', [TestResultController::class, 'download'])->name('test-results.download');
+    Route::post('/test-results/{testResult}/pdf', [TestResultController::class, 'pdf'])->name('test-results.pdf');
 });
 
 Route::get('/login', function () {


### PR DESCRIPTION
## Summary
- add optional chart screenshot support to MrtPdfService and Blade template
- expose API endpoint for generating MRT PDFs with chart
- capture DOM screenshot on client and request server-side PDF download

## Testing
- `npm run lint` *(fails: 27 errors)*
- `npm run format:check`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4f609c5c8329a789b10edfcc1094