### PR TITLE
Add PDF export for MRT test results and participant download option

### DIFF
--- a/app/Services/MrtPdfService.php
+++ b/app/Services/MrtPdfService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TestResult;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class MrtPdfService
+{
+    public static function generate(TestResult $result): ?string
+    {
+        if (!class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
+            return null;
+        }
+
+        $participantName = $result->assignment->participant->name ?? 'participant';
+        $testName = $result->assignment->test->name ?? 'test';
+        $json = $result->result_json ?? [];
+
+        $data = [
+            'test_name' => $testName,
+            'date' => now()->format('d.m.Y'),
+            'participant_name' => $participantName,
+            'total_score' => $json['total_score'] ?? null,
+            'total_time_seconds' => $json['total_time_seconds'] ?? null,
+            'prozentrang' => $json['prozentrang'] ?? null,
+            'group_scores' => $json['group_scores'] ?? [],
+            'group_stanines' => $json['group_stanines'] ?? [],
+            'answers' => self::formatAnswers($json['answers'] ?? []),
+            'chart_image' => self::chartImage($json['group_stanines'] ?? []),
+        ];
+
+        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('pdfs.mrt-result', $data)->setPaper('a4');
+        $fileName = Str::slug($participantName, '_') . '_' . Str::slug($testName, '_') . '.pdf';
+        $path = 'test_results/' . $fileName;
+        Storage::put($path, $pdf->output());
+        return $path;
+    }
+
+    protected static function formatAnswers(array $answers): array
+    {
+        return array_map(function ($a) {
+            $a['correct'] = isset($a['correct_answers']) ? implode(', ', $a['correct_answers']) : '';
+            $a['time_formatted'] = isset($a['time_seconds']) ? self::formatTime($a['time_seconds']) : '–';
+            return $a;
+        }, $answers);
+    }
+
+    protected static function formatTime(?int $seconds): string
+    {
+        if ($seconds === null) {
+            return '–';
+        }
+        $minutes = floor($seconds / 60);
+        $secs = $seconds % 60;
+        return sprintf('%02d:%02d', $minutes, $secs);
+    }
+
+    protected static function chartImage(array $stanines): ?string
+    {
+        if (empty($stanines)) {
+            return null;
+        }
+        $config = [
+            'type' => 'line',
+            'data' => [
+                'labels' => ['U1','U2','U3','U4','U5','U6'],
+                'datasets' => [[
+                    'label' => 'SN',
+                    'data' => array_values($stanines),
+                    'borderColor' => '#1d4ed8',
+                    'backgroundColor' => '#1d4ed8',
+                    'fill' => false,
+                    'tension' => 0,
+                    'pointRadius' => 3,
+                ]],
+            ],
+            'options' => [
+                'plugins' => ['legend' => ['display' => false]],
+                'scales' => [
+                    'y' => ['min' => 1, 'max' => 9]
+                ],
+            ],
+        ];
+        $url = 'https://quickchart.io/chart?width=480&height=320&c=' . urlencode(json_encode($config));
+        try {
+            $image = file_get_contents($url);
+            if ($image !== false) {
+                return base64_encode($image);
+            }
+        } catch (\Exception $e) {
+            return null;
+        }
+        return null;
+    }
+}

--- a/resources/js/pages/Participant.vue
+++ b/resources/js/pages/Participant.vue
@@ -44,6 +44,12 @@ function submit() {
   form.post('/onboarding')
 }
 
+function downloadPdf(id: number) {
+  if (id) {
+    window.open(route('test-results.download', { testResult: id }), '_blank')
+  }
+}
+
 const handleLogout = () => {
   router.flushAll();
 };
@@ -194,11 +200,17 @@ const householdOptions = [
 
       <div v-if="props.mrtAResult" class="w-full max-w-4xl">
         <h2 class="text-2xl font-bold text-center mb-4">MRT-A Ergebnisse</h2>
-        <MrtAResult :results="props.mrtAResult" />
+        <div class="flex justify-end mb-2">
+          <button class="text-sm underline" @click="downloadPdf(props.mrtAResult.id)">PDF herunterladen</button>
+        </div>
+        <MrtAResult :results="props.mrtAResult.result_json" />
       </div>
       <div v-if="props.mrtBResult" class="w-full max-w-4xl mt-8">
         <h2 class="text-2xl font-bold text-center mb-4">MRT-B Ergebnisse</h2>
-        <MrtBResult :results="props.mrtBResult" />
+        <div class="flex justify-end mb-2">
+          <button class="text-sm underline" @click="downloadPdf(props.mrtBResult.id)">PDF herunterladen</button>
+        </div>
+        <MrtBResult :results="props.mrtBResult.result_json" />
       </div>
     </div>
   </div>

--- a/resources/views/pdfs/mrt-result.blade.php
+++ b/resources/views/pdfs/mrt-result.blade.php
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+        th, td { border: 1px solid #000; padding: 4px; text-align: left; }
+        .info-table { width: 60%; margin-bottom: 20px; }
+        .chart { margin-top: 20px; }
+        .progress { width:400px;height:20px;border:1px solid #000;margin-top:20px; }
+        .progress-bar { height:100%; background-color:#dc2626; }
+    </style>
+</head>
+<body>
+    <h1>{{ $test_name }}</h1>
+    <p>Datum: {{ $date }}</p>
+    <p>Teilnehmer: {{ $participant_name }}</p>
+
+    <table class="info-table">
+        <tr>
+            <th>Rohwert</th>
+            <td>{{ $total_score }} von 60</td>
+        </tr>
+        <tr>
+            <th>Benötigte Zeit</th>
+            <td>
+                @if(!is_null($total_time_seconds))
+                    {{ sprintf('%02d:%02d', intdiv($total_time_seconds,60), $total_time_seconds%60) }} Minuten
+                @else
+                    –
+                @endif
+            </td>
+        </tr>
+        <tr>
+            <th>Prozentrang</th>
+            <td>{{ $prozentrang }}</td>
+        </tr>
+    </table>
+
+    @if($chart_image)
+    <div class="chart">
+        <img src="data:image/png;base64,{{ $chart_image }}" width="480" height="320" alt="Chart">
+    </div>
+    @endif
+
+    <div class="progress">
+        <div class="progress-bar" style="width: {{ $prozentrang }}%"></div>
+    </div>
+
+    <h3>Antworten</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Antwort</th>
+                <th>Richtig</th>
+                <th>Zeit (mm:ss)</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($answers as $a)
+            <tr>
+                <td>{{ $a['number'] }}</td>
+                <td>{{ $a['user_answer'] ?? '–' }}</td>
+                <td>{{ $a['correct'] }}</td>
+                <td>{{ $a['time_formatted'] }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Generate MRT-A/B result PDFs including chart and answer details via new `MrtPdfService`
- Store and expose MRT PDF paths in `ParticipantController` and generate PDFs when tests are completed
- Add PDF download buttons to participant result view for MRT-A and MRT-B

## Testing
- `npm test` *(fails: Missing script "test")*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a36916148329baaa189f939ad2e5