### PR TITLE
Implement AVEM scoring and result display

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -198,6 +198,9 @@ class ParticipantController extends Controller
           $profile = $user->participantProfile;
           $sex = $profile->sex ?? null;
           $resultData = \App\Services\Bit2Scorer::score($answers, $sex);
+        } elseif ($examStep->test->name === 'AVEM') {
+          $answers = $results['answers'] ?? [];
+          $resultData = \App\Services\AvemScorer::score($answers);
         }
 
         $testResult = TestResult::create([

--- a/app/Services/AvemScorer.php
+++ b/app/Services/AvemScorer.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Services;
+
+class AvemScorer
+{
+    /**
+     * Mapping of category codes to their scoring formulas.
+     * Each entry contains a constant and an array of question numbers.
+     * Positive numbers are added, negative numbers are subtracted.
+     */
+    protected static array $categories = [
+        'SBA' => [
+            'label' => 'Subjektive Bedeutsamkeit der Arbeit',
+            'constant' => 12,
+            'items' => [1, 12, -23, 34, 45, -56],
+        ],
+        'BE' => [
+            'label' => 'Beruflicher Ehrgeiz',
+            'constant' => 6,
+            'items' => [2, -13, 24, 35, 46, 57],
+        ],
+        'VB' => [
+            'label' => 'Verausgabungsbereitschaft',
+            'constant' => 0,
+            'items' => [3, 14, 25, 36, 47, 58],
+        ],
+        'PS' => [
+            'label' => 'Perfektionsstreben',
+            'constant' => 0,
+            'items' => [4, 15, 26, 37, 48, 59],
+        ],
+        'DF' => [
+            'label' => 'Distanzierungsfähigkeit',
+            'constant' => 18,
+            'items' => [5, -16, 27, 38, -49, -60],
+        ],
+        'RT' => [
+            'label' => 'Resignationstendenz (bei Misserfolg)',
+            'constant' => 0,
+            'items' => [6, 17, 28, 39, 50, 61],
+        ],
+        'OP' => [
+            'label' => 'Offensive Problembewältigung',
+            'constant' => 0,
+            'items' => [7, 18, 29, 40, 51, 62],
+        ],
+        'IR' => [
+            'label' => 'Innere Ruhe/Ausgeglichenheit',
+            'constant' => 12,
+            'items' => [8, -19, -30, 41, 52, 63],
+        ],
+        'EB' => [
+            'label' => 'Erfolgserleben im Beruf',
+            'constant' => 6,
+            'items' => [9, 20, -31, 42, 53, 64],
+        ],
+        'LZ' => [
+            'label' => 'Lebenszufriedenheit',
+            'constant' => 6,
+            'items' => [10, 21, 32, 43, -54, 65],
+        ],
+        'SU' => [
+            'label' => 'Erleben sozialer Unterstützung',
+            'constant' => 18,
+            'items' => [11, -22, -33, 44, -55, 66],
+        ],
+    ];
+
+    public static function score(array $answers): array
+    {
+        $answerMap = [];
+        foreach ($answers as $entry) {
+            $num = $entry['number'] ?? null;
+            $ans = $entry['answer'] ?? null;
+            if ($num === null || $ans === null) {
+                continue;
+            }
+            $answerMap[(int) $num] = (int) $ans;
+        }
+
+        $scores = [];
+        foreach (self::$categories as $code => $data) {
+            $score = $data['constant'] ?? 0;
+            foreach ($data['items'] as $item) {
+                $qNum = abs($item);
+                $val = $answerMap[$qNum] ?? 0;
+                $score += $item < 0 ? -$val : $val;
+            }
+            $scores[$code] = $score;
+        }
+
+        return [
+            'category_scores' => $scores,
+            'answers' => $answers,
+        ];
+    }
+}
+

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -17,6 +17,19 @@ import { norms_male_45_59 } from '@/pages/Scores/FPI/norms_male_45_59';
 import { norms_male_60up } from '@/pages/Scores/FPI/norms_male_60up';
 import { computed, ref, watch } from 'vue';
 const bit2Groups = ['TH', 'GH', 'TN', 'EH', 'LF', 'KB', 'VB', 'LG', 'SE'];
+const avemCategories = [
+    { key: 'SBA', label: 'Subjektive Bedeutsamkeit der Arbeit' },
+    { key: 'BE', label: 'Beruflicher Ehrgeiz' },
+    { key: 'VB', label: 'Verausgabungsbereitschaft' },
+    { key: 'PS', label: 'Perfektionsstreben' },
+    { key: 'DF', label: 'Distanzierungsfähigkeit' },
+    { key: 'RT', label: 'Resignationstendenz (bei Misserfolg)' },
+    { key: 'OP', label: 'Offensive Problembewältigung' },
+    { key: 'IR', label: 'Innere Ruhe/Ausgeglichenheit' },
+    { key: 'EB', label: 'Erfolgserleben im Beruf' },
+    { key: 'LZ', label: 'Lebenszufriedenheit' },
+    { key: 'SU', label: 'Erleben sozialer Unterstützung' },
+];
 
 interface Answer {
     question: string;
@@ -268,6 +281,20 @@ const fpiRohwerte = computed(() => {
             </table>
         </div>
         <div v-else-if="test.name === 'AVEM'" class="overflow-x-auto">
+            <table class="mb-4 w-full overflow-hidden rounded-lg border text-sm shadow">
+                <thead class="bg-muted/40 dark:bg-gray-700">
+                    <tr>
+                        <th class="px-3 py-2 text-left font-semibold">Kategorie</th>
+                        <th class="px-3 py-2 text-center font-semibold">Score</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="cat in avemCategories" :key="cat.key" class="dark:bg-gray-800">
+                        <td class="px-3 py-2">{{ cat.label }}</td>
+                        <td class="px-3 py-2 text-center">{{ local.category_scores?.[cat.key] ?? 0 }}</td>
+                    </tr>
+                </tbody>
+            </table>
             <table class="min-w-full border text-sm">
                 <thead class="bg-muted/40 dark:bg-gray-700">
                     <tr>

--- a/tests/Unit/AvemScorerTest.php
+++ b/tests/Unit/AvemScorerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Services\AvemScorer;
+
+test('avem scorer calculates category scores', function () {
+    $answers = [];
+    for ($i = 1; $i <= 66; $i++) {
+        $answers[] = ['number' => $i, 'answer' => 3];
+    }
+
+    $result = AvemScorer::score($answers);
+    expect($result['category_scores'])->toBe([
+        'SBA' => 18,
+        'BE' => 18,
+        'VB' => 18,
+        'PS' => 18,
+        'DF' => 18,
+        'RT' => 18,
+        'OP' => 18,
+        'IR' => 18,
+        'EB' => 18,
+        'LZ' => 18,
+        'SU' => 18,
+    ]);
+});
+


### PR DESCRIPTION
## Summary
- add AVEM scoring service with 11 category calculations
- hook AVEM scorer into participant workflow
- show AVEM category scores in result viewer
- add basic unit test for AVEM scorer

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: needs GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f10b150c83298e67557434ec4ced