### PR TITLE
Fix AVEM results to show question text and labels

### DIFF
--- a/resources/js/components/AvemResult.vue
+++ b/resources/js/components/AvemResult.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { AVEM_QUESTIONS } from '@/pages/Questions/AVEMQuestions'
+
+const props = defineProps<{ results: any }>()
+
+const LABELS: Record<number, string> = {
+  5: 'trifft völlig zu',
+  4: 'trifft überwiegend zu',
+  3: 'teils/teils',
+  2: 'trifft überwiegend nicht zu',
+  1: 'trifft überhaupt nicht zu',
+}
+
+const questionMap = AVEM_QUESTIONS.reduce((acc, q) => {
+  acc[q.number] = q.text
+  return acc
+}, {} as Record<number, string>)
+
+const rows = computed(() => {
+  return (props.results?.answers ?? []).map((ans: any, idx: number) => ({
+    number: ans.number ?? idx + 1,
+    question: questionMap[ans.number ?? idx + 1] ?? '',
+    answer:
+      ans.answer == null ? '–' : LABELS[Number(ans.answer)] ?? String(ans.answer),
+  }))
+})
+</script>
+
+<template>
+  <div class="overflow-x-auto">
+    <table class="min-w-full border text-sm">
+      <thead class="bg-muted/40 dark:bg-gray-700">
+        <tr>
+          <th class="px-2 py-1 text-left font-semibold">#</th>
+          <th class="px-2 py-1 text-left font-semibold">Frage</th>
+          <th class="px-2 py-1 text-left font-semibold">Antwort</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in rows" :key="row.number">
+          <td class="px-2 py-1">{{ row.number }}</td>
+          <td class="px-2 py-1">{{ row.question }}</td>
+          <td class="px-2 py-1">{{ row.answer }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -5,6 +5,7 @@ defineOptions({
 import LmtResult from '@/components/LmtResult.vue';
 import MrtAResult from '@/components/MrtAResult.vue';
 import MrtBResult from '@/components/MrtBResult.vue';
+import AvemResult from '@/components/AvemResult.vue';
 import { Input } from '@/components/ui/input';
 import FpiResult from '@/pages/Scores/FPI/FPIResult.vue';
 import { norms_female_16_24 } from '@/pages/Scores/FPI/norms_female_16_24';
@@ -267,22 +268,7 @@ const fpiRohwerte = computed(() => {
                 </tbody>
             </table>
         </div>
-        <div v-else-if="test.name === 'AVEM'" class="overflow-x-auto">
-            <table class="min-w-full border text-sm">
-                <thead class="bg-muted/40 dark:bg-gray-700">
-                    <tr>
-                        <th class="px-2 py-1 text-left font-semibold">#</th>
-                        <th class="px-2 py-1 text-left font-semibold">Antwort</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr v-for="(ans, idx) in local.answers" :key="idx">
-                        <td class="px-2 py-1">{{ ans.number ?? idx + 1 }}</td>
-                        <td class="px-2 py-1">{{ ans.answer }}</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+        <AvemResult v-else-if="test.name === 'AVEM'" :results="local" />
         <template v-else>
             <table class="mb-4 w-full overflow-hidden rounded-lg border text-sm shadow">
                 <tbody>


### PR DESCRIPTION
## Summary
- create dedicated `AvemResult` component to map answer codes to text and labels
- update `TestResultViewer` to render the new component for AVEM tests

## Testing
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm test` *(fails: Missing script "test")*
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c41ade4ac08329a8872d01d15d0caf