### PR TITLE
Add initial Konzentrationstest skeleton

### DIFF
--- a/app/Ldap/ImportUser.php
+++ b/app/Ldap/ImportUser.php
@@ -70,7 +70,7 @@ class ImportUser
     $eloquentUser->save();
     if ($role === 'participant') {
       if (TestAssignment::where('participant_id', $eloquentUser->id)->count() === 0) {
-        $defaultCodes = ['BRT-A','BRT-B', 'MRT-A', 'FPI-R', 'LMT', 'BIT-2', 'AVEM'];
+        $defaultCodes = ['BRT-A','BRT-B', 'MRT-A', 'FPI-R', 'LMT', 'BIT-2', 'AVEM', 'Konzentrationstest'];
         $defaultTests = Test::whereIn('code', $defaultCodes)->get();
 
         foreach ($defaultTests as $test) {

--- a/database/seeders/TestsTableSeeder.php
+++ b/database/seeders/TestsTableSeeder.php
@@ -20,6 +20,7 @@ class TestsTableSeeder extends Seeder
       ['name' => 'LMT',   'code' => 'LMT', 'duration' => 60],
       ['name' => 'BIT-2', 'code' => 'BIT-2', 'duration' => 60],
       ['name' => 'AVEM', 'code' => 'AVEM', 'duration' => 60],
+      ['name' => 'Konzentrationstest', 'code' => 'Konzentrationstest', 'duration' => 60],
     ];
 
     foreach ($tests as $test) {

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -59,6 +59,11 @@ const mainNavItems: NavItem[] = [
         href: '/avem', // The new route for the Tests page
         icon: LayoutGrid, // Placeholder icon, can be changed later
     },
+    {
+        title: 'Konzentrationstest',
+        href: '/konzentrationstest',
+        icon: LayoutGrid,
+    },
 ];
 
 const footerNavItems: NavItem[] = [

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -16,6 +16,7 @@ import LMT from '@/pages/LMT.vue';
 import LMT2 from '@/pages/LMT2.vue';
 import MRTA from '@/pages/MRT-A.vue';
 import MRTB from '@/pages/MRT-B.vue';
+import KONZ from '@/pages/Konzentrationstest.vue';
 
 type StepStatus = 'not_started' | 'in_progress' | 'completed' | 'broken';
 type ExamStatus = 'not_started' | 'in_progress' | 'paused' | 'completed';
@@ -60,6 +61,7 @@ const testComponents = {
     LMT2: LMT2,
     'BIT-2': BIT2,
     AVEM: AVEM,
+    Konzentrationstest: KONZ,
 };
 
 function getStatusText(status: StepStatus) {

--- a/resources/js/pages/Konzentrationstest.vue
+++ b/resources/js/pages/Konzentrationstest.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3';
+import { ref, computed } from 'vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+const page = ref(1);
+
+const page1Questions = [
+  { seq: '20 . 10 . 18 . 14 . 7 . ?', answer: '11' },
+  { seq: '12 . 21 . 29 . 38 . ?', answer: '47' },
+  { seq: '19 . 12 . 22 . 18 . 27 . ?', answer: '23' },
+];
+const page1Responses = ref(Array(page1Questions.length).fill(''));
+
+const page2Answer = ref('');
+const page2Correct = 'Example';
+
+const page5Text = 'u n u u n u';
+const page5Marks = ref<boolean[]>(page5Text.split(' ').map(() => false));
+const page5Sum = ref('');
+
+const page6Rows = [
+  '896586569856',
+  '658969856985',
+  '985689568965',
+];
+const page6Answers = ref<string[]>(Array(page6Rows.length).fill(''));
+const page6Correct = ['3', '2', '4'];
+
+const page7Chars = ['A', '%', 'B', '$', 'C', '&', 'D'];
+const page7Marks = ref<boolean[]>(page7Chars.map(() => false));
+const page7Total = ref('');
+
+const wrongCount = computed(() => {
+  let wrong = 0;
+  page1Questions.forEach((q, i) => {
+    if (page1Responses.value[i].trim() !== q.answer) wrong++;
+  });
+  if (page2Answer.value.trim() !== page2Correct) wrong++;
+  page6Rows.forEach((row, i) => {
+    if (page6Answers.value[i].trim() !== page6Correct[i]) wrong++;
+  });
+  return wrong;
+});
+
+const percentage = computed(() => {
+  const wrong = wrongCount.value;
+  if (wrong <= 5) return '92 - 100%';
+  if (wrong <= 13) return '81 - 91%';
+  if (wrong <= 22) return '67 - 80%';
+  if (wrong <= 33) return '50 - 66%';
+  if (wrong <= 60) return '30 - 49%';
+  return '0 - 29%';
+});
+
+function nextPage() {
+  if (page.value < 7) page.value++;
+}
+function prevPage() {
+  if (page.value > 1) page.value--;
+}
+function toggleMark(marks: boolean[], index: number) {
+  marks[index] = !marks[index];
+}
+</script>
+
+<template>
+  <Head title="Konzentrationstest" />
+  <div class="p-4">
+    <div v-if="page === 1">
+      <h1 class="text-2xl font-bold mb-4">Seite 1</h1>
+      <div v-for="(q, i) in page1Questions" :key="i" class="mb-2">
+        <span class="mr-2">{{ q.seq }}</span>
+        <Input v-model="page1Responses[i]" class="inline w-24" />
+      </div>
+    </div>
+
+    <div v-else-if="page === 2">
+      <h1 class="text-2xl font-bold mb-4">Seite 2</h1>
+      <p class="mb-4">Nutzen Sie die Information auf Seite 3 und geben Sie die richtige Antwort ein.</p>
+      <Input v-model="page2Answer" placeholder="Antwort" class="w-64" />
+    </div>
+
+    <div v-else-if="page === 3">
+      <h1 class="text-2xl font-bold mb-4">Seite 3</h1>
+      <p>Referenzinformationen für Seite 2.</p>
+      <p class="mt-2 text-sm">Beispieldaten: Beispielstraße 1, 12345 Beispielstadt</p>
+    </div>
+
+    <div v-else-if="page === 4">
+      <h1 class="text-2xl font-bold mb-4">Seite 4</h1>
+      <p>Prüfen Sie die Schreibweise und markieren Sie Fehler auf Seite 5.</p>
+    </div>
+
+    <div v-else-if="page === 5">
+      <h1 class="text-2xl font-bold mb-4">Seite 5</h1>
+      <div class="mb-4">
+        <span
+          v-for="(ch, i) in page5Text.split(' ')"
+          :key="i"
+          @click="toggleMark(page5Marks, i)"
+          :class="{'mark-over': page5Marks[i]}"
+          class="cursor-pointer px-1"
+        >{{ ch }}</span>
+      </div>
+      <Input v-model="page5Sum" placeholder="Summe der Fehler" class="w-48" />
+    </div>
+
+    <div v-else-if="page === 6">
+      <h1 class="text-2xl font-bold mb-4">Seite 6</h1>
+      <p class="mb-2">Zählen Sie die Anzahl der 6er in jeder Zeile.</p>
+      <div v-for="(row, i) in page6Rows" :key="i" class="mb-2">
+        <span class="font-mono mr-2">{{ row }}</span>
+        <Input v-model="page6Answers[i]" class="inline w-16" />
+      </div>
+    </div>
+
+    <div v-else-if="page === 7">
+      <h1 class="text-2xl font-bold mb-4">Seite 7</h1>
+      <div class="mb-4">
+        <span
+          v-for="(ch, i) in page7Chars"
+          :key="i"
+          @click="toggleMark(page7Marks, i)"
+          :class="{'underline-double': page7Marks[i]}"
+          class="cursor-pointer px-1"
+        >{{ ch }}</span>
+      </div>
+      <Input v-model="page7Total" placeholder="Gefundene Zeichen" class="w-48" />
+      <div class="mt-4">
+        <p>Falsche Antworten: {{ wrongCount }}</p>
+        <p>Prozent: {{ percentage }}</p>
+      </div>
+    </div>
+
+    <div class="mt-6 flex gap-2">
+      <Button @click="prevPage" v-if="page > 1">Zurück</Button>
+      <Button @click="nextPage" v-if="page < 7">Weiter</Button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.mark-over {
+  text-decoration: overline red;
+}
+.underline-double {
+  text-decoration: underline red;
+  text-decoration-thickness: 2px;
+}
+</style>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::get('lmt2', fn () => Inertia::render('LMT2'))->name('lmt2');
     Route::get('bit-2', fn () => Inertia::render('BIT-2'))->name('bit-2');
     Route::get('avem', fn () => Inertia::render('AVEM'))->name('avem');
+    Route::get('konzentrationstest', fn () => Inertia::render('Konzentrationstest'))->name('konzentrationstest');
     Route::post('assign-tests', [TeacherController::class, 'assignTests'])->name('assign.tests');
     Route::post('remove-tests', [TeacherController::class, 'removeTests'])->name('remove.tests');
     Route::get('/onboarding', [ParticipantController::class, 'showProfileForm'])->name('participant.onboarding');


### PR DESCRIPTION
## Summary
- add new Vue page for Konzentrationstest with seven interactive sections and scoring
- register Konzentrationstest in navigation, routes, exam room, seeder, and default assignments

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: missing PHP ldap extension)*

------
https://chatgpt.com/codex/tasks/task_e_68c8064679488329ad176f0187416b47