### PR TITLE
Stabilize exam autosave and resume behavior

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,6 +46,7 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user()?->load('participantProfile'),
             ],
+            'csrfToken' => csrf_token(),
             'ziggy' => [
                 ...(new Ziggy)->toArray(),
                 'location' => $request->url(),

--- a/app/Models/ExamStepStatus.php
+++ b/app/Models/ExamStepStatus.php
@@ -14,7 +14,16 @@ class ExamStepStatus extends Model
     'duration',
     'extra_time',
     'started_at',
-    'completed_at'
+    'completed_at',
+    'progress',
+    'last_saved_at'
+  ];
+
+  protected $casts = [
+    'progress' => 'array',
+    'started_at' => 'datetime',
+    'completed_at' => 'datetime',
+    'last_saved_at' => 'datetime',
   ];
 
   public function exam()

--- a/database/migrations/2025_08_02_000000_add_progress_to_exam_step_statuses_table.php
+++ b/database/migrations/2025_08_02_000000_add_progress_to_exam_step_statuses_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('exam_step_statuses', function (Blueprint $table) {
+            $table->json('progress')->nullable()->after('completed_at');
+            $table->timestamp('last_saved_at')->nullable()->after('progress');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('exam_step_statuses', function (Blueprint $table) {
+            $table->dropColumn(['progress', 'last_saved_at']);
+        });
+    }
+};

--- a/resources/js/lib/deepClone.ts
+++ b/resources/js/lib/deepClone.ts
@@ -1,0 +1,7 @@
+export function deepClone<T>(value: T): T {
+    if (value === null || value === undefined) {
+        return value;
+    }
+
+    return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/resources/js/pages/BIT-2.vue
+++ b/resources/js/pages/BIT-2.vue
@@ -3,9 +3,18 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { BIT2_QUESTIONS } from '@/pages/Questions/BIT2Questions';
 import { Head } from '@inertiajs/vue3';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
+import { deepClone } from '@/lib/deepClone';
 
 const emit = defineEmits(['complete']);
+
+interface Bit2ProgressState {
+    started: boolean;
+    pageIndex: number;
+    answers: Record<number, number | null>;
+}
+
+const props = defineProps<{ initialState?: Bit2ProgressState | null }>();
 
 const showTest = ref(false);
 const pageIndex = ref(0); // 0 first 27, 1 remaining
@@ -46,11 +55,43 @@ function confirmEnd() {
     };
     emit('complete', results);
 }
+
+function loadProgress(state?: Bit2ProgressState | null) {
+    if (!state) return;
+    showTest.value = !!state.started;
+    if (typeof state.pageIndex === 'number') {
+        pageIndex.value = state.pageIndex;
+    }
+    if (state.answers) {
+        answers.value = { ...answers.value, ...state.answers };
+    }
+}
+
+function getProgress(): Bit2ProgressState {
+    return {
+        started: showTest.value,
+        pageIndex: pageIndex.value,
+        answers: deepClone(answers.value),
+    };
+}
+
+watch(
+    () => props.initialState,
+    (state) => {
+        loadProgress(state ?? null);
+    },
+    { immediate: true, deep: true },
+);
+
+defineExpose({
+    getProgress,
+    loadProgress,
+});
 </script>
 
 <template>
-    <Head title="BIT-2" />
-    <div class="p-4">
+    <div v-bind="$attrs" class="p-4">
+        <Head title="BIT-2" />
         <div class="mb-4 flex items-center justify-between">
             <h1 class="text-2xl font-bold">BIT-2</h1>
         </div>

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3';
+import { Head } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
+import { deepClone } from '@/lib/deepClone';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -13,6 +14,17 @@ import {
 } from '@/components/ui/dialog';
 
 const emit = defineEmits(['complete']);
+
+interface BrtAProgressState {
+  started: boolean;
+  currentQuestionIndex: number;
+  nextButtonClickCount: number;
+  userAnswers: string[];
+  questionTimes: number[];
+  startTime: number | null;
+}
+
+const props = defineProps<{ initialState?: BrtAProgressState | null }>();
 
 interface Question {
   text: string;
@@ -75,18 +87,23 @@ const isLastQuestion = computed(
   () => currentQuestionIndex.value === questions.value.length - 1
 );
 
-const jumpToQuestion = (index: number) => {
-  const now = Date.now();
+const commitCurrentQuestionTime = () => {
+  const index = currentQuestionIndex.value;
   if (
-    currentQuestionIndex.value >= 0 &&
-    currentQuestionIndex.value < questions.value.length &&
-    questionStartTimestamps.value[currentQuestionIndex.value]
+    index >= 0 &&
+    index < questions.value.length &&
+    questionStartTimestamps.value[index]
   ) {
-    questionTimes.value[currentQuestionIndex.value] += Math.round(
-      (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
+    const now = Date.now();
+    questionTimes.value[index] += Math.round(
+      (now - (questionStartTimestamps.value[index] as number)) / 1000
     );
-    questionStartTimestamps.value[currentQuestionIndex.value] = null;
+    questionStartTimestamps.value[index] = null;
   }
+};
+
+const jumpToQuestion = (index: number) => {
+  commitCurrentQuestionTime();
   currentQuestionIndex.value = index;
   nextButtonClickCount.value = 0;
 };
@@ -94,17 +111,7 @@ const jumpToQuestion = (index: number) => {
 const handleNextClick = () => {
   nextButtonClickCount.value++;
   if (nextButtonClickCount.value >= 2) {
-    const now = Date.now();
-    if (
-      currentQuestionIndex.value >= 0 &&
-      currentQuestionIndex.value < questions.value.length &&
-      questionStartTimestamps.value[currentQuestionIndex.value]
-    ) {
-      questionTimes.value[currentQuestionIndex.value] += Math.round(
-        (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
-      );
-      questionStartTimestamps.value[currentQuestionIndex.value] = null;
-    }
+    commitCurrentQuestionTime();
     if (currentQuestionIndex.value < questions.value.length - 1) {
       currentQuestionIndex.value++;
       nextButtonClickCount.value = 0;
@@ -117,17 +124,7 @@ const handleNextClick = () => {
 };
 
 const handlePrevClick = () => {
-  const now = Date.now();
-  if (
-    currentQuestionIndex.value >= 0 &&
-    currentQuestionIndex.value < questions.value.length &&
-    questionStartTimestamps.value[currentQuestionIndex.value]
-  ) {
-    questionTimes.value[currentQuestionIndex.value] += Math.round(
-      (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
-    );
-    questionStartTimestamps.value[currentQuestionIndex.value] = null;
-  }
+  commitCurrentQuestionTime();
   if (currentQuestionIndex.value > 0) {
     currentQuestionIndex.value--;
     nextButtonClickCount.value = 0;
@@ -140,17 +137,7 @@ const finishTest = () => {
 };
 
 const confirmEnd = () => {
-  const now = Date.now();
-  if (
-    currentQuestionIndex.value >= 0 &&
-    currentQuestionIndex.value < questions.value.length &&
-    questionStartTimestamps.value[currentQuestionIndex.value]
-  ) {
-    questionTimes.value[currentQuestionIndex.value] += Math.round(
-      (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
-    );
-    questionStartTimestamps.value[currentQuestionIndex.value] = null;
-  }
+  commitCurrentQuestionTime();
   currentQuestionIndex.value = questions.value.length;
   nextButtonClickCount.value = 0;
   endConfirmOpen.value = false;
@@ -166,6 +153,65 @@ const cancelEnd = () => {
   window.dispatchEvent(new Event('cancel-finish'));
   endConfirmOpen.value = false;
 };
+
+function loadProgress(state?: BrtAProgressState | null) {
+  if (!state) return;
+
+  showTest.value = !!state.started;
+
+  const totalQuestions = questions.value.length;
+
+  const restoredAnswers = Array(totalQuestions).fill('');
+  if (Array.isArray(state.userAnswers)) {
+    state.userAnswers.slice(0, totalQuestions).forEach((answer, index) => {
+      restoredAnswers[index] = answer ?? '';
+    });
+  }
+  userAnswers.value = restoredAnswers;
+
+  const restoredTimes = Array(totalQuestions).fill(0);
+  if (Array.isArray(state.questionTimes)) {
+    state.questionTimes.slice(0, totalQuestions).forEach((time, index) => {
+      restoredTimes[index] = typeof time === 'number' ? time : 0;
+    });
+  }
+  questionTimes.value = restoredTimes;
+  questionStartTimestamps.value = Array(totalQuestions).fill(null);
+
+  nextButtonClickCount.value = state.nextButtonClickCount ?? 0;
+  startTime.value = typeof state.startTime === 'number' ? state.startTime : null;
+
+  const index = typeof state.currentQuestionIndex === 'number'
+    ? Math.min(Math.max(state.currentQuestionIndex, 0), totalQuestions)
+    : 0;
+  currentQuestionIndex.value = index;
+}
+
+function getProgress(): BrtAProgressState {
+  commitCurrentQuestionTime();
+
+  return {
+    started: showTest.value,
+    currentQuestionIndex: currentQuestionIndex.value,
+    nextButtonClickCount: nextButtonClickCount.value,
+    userAnswers: deepClone(userAnswers.value),
+    questionTimes: deepClone(questionTimes.value),
+    startTime: startTime.value,
+  };
+}
+
+watch(
+  () => props.initialState,
+  (state) => {
+    loadProgress(state ?? null);
+  },
+  { immediate: true, deep: true },
+);
+
+defineExpose({
+  getProgress,
+  loadProgress,
+});
 
 // Per-question timer starter
 watch(currentQuestionIndex, async (newIndex, oldIndex) => {
@@ -207,33 +253,40 @@ const startTest = () => {
 </script>
 
 <template>
-
-  <Head title="Tests" />
-  <div class="p-4">
-    <div class="flex justify-between items-center mb-4">
+  <div v-bind="$attrs" class="p-4">
+    <Head title="Tests" />
+    <div class="mb-4 flex items-center justify-between">
       <h1 class="text-2xl font-bold">BRT-A</h1>
     </div>
-    <div class="flex flex-1 min-h-[600px] gap-4 rounded-xl p-4 bg-muted/20">
-      <!-- Sidebar Navigation: Only visible during the test -->
-      <aside v-if="showTest" class="w-64 flex-shrink-0 flex flex-col items-start space-y-2  py-4 h-fit sticky top-8">
-        <h3 class="font-bold mb-2 text-sm text-muted-foreground pl-4">Fragen</h3>
-        <div class="flex flex-col space-y-1 w-full items-start">
+    <div class="flex min-h-[600px] flex-1 gap-4 rounded-xl bg-muted/20 p-4">
+      <aside
+        v-if="showTest"
+        class="sticky top-8 flex h-fit w-64 flex-shrink-0 flex-col items-start space-y-2 py-4"
+      >
+        <h3 class="mb-2 pl-4 text-sm font-bold text-muted-foreground">Fragen</h3>
+        <div class="flex w-full flex-col items-start space-y-1">
           <template v-for="(q, idx) in questions" :key="idx">
-            <button class="w-full flex items-center space-x-2 py-1 px-2 rounded-lg font-medium border transition
-               hover:bg-blue-50 focus:outline-none text-base" :class="{
-                'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
-                'hover:bg-blue-500': idx === currentQuestionIndex,
+            <button
+              class="flex w-full items-center space-x-2 rounded-lg border px-2 py-1 font-medium transition hover:bg-blue-50 focus:outline-none text-base"
+              :class="{
+                'bg-blue-600 text-white border-blue-600 hover:bg-blue-500': idx === currentQuestionIndex,
                 'bg-gray-300 border-gray-400 text-gray-900': userAnswers[idx] && idx !== currentQuestionIndex,
                 'bg-gray-100 border-gray-300 text-gray-900': !userAnswers[idx] && idx !== currentQuestionIndex,
-              }" @click="jumpToQuestion(idx)" :disabled="isTestComplete || !showTest">
-              <span class="w-8 h-8 flex items-center justify-center rounded-full border mr-2" :class="{
-                'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
-                'bg-gray-400 text-white border-gray-400': userAnswers[idx] && idx !== currentQuestionIndex,
-                'bg-gray-300 text-gray-600 border-gray-400': !userAnswers[idx] && idx !== currentQuestionIndex,
-              }">
+              }"
+              @click="jumpToQuestion(idx)"
+              :disabled="isTestComplete || !showTest"
+            >
+              <span
+                class="mr-2 flex h-8 w-8 items-center justify-center rounded-full border"
+                :class="{
+                  'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
+                  'bg-gray-400 text-white border-gray-400': userAnswers[idx] && idx !== currentQuestionIndex,
+                  'bg-gray-300 text-gray-600 border-gray-400': !userAnswers[idx] && idx !== currentQuestionIndex,
+                }"
+              >
                 {{ idx + 1 }}
               </span>
-              <span class="truncate max-w-[130px] text-left text-xs" :title="q.text">
+              <span class="max-w-[130px] truncate text-left text-xs" :title="q.text">
                 {{ q.text.length > 30 ? q.text.slice(0, 30) + '…' : q.text }}
               </span>
             </button>
@@ -241,37 +294,42 @@ const startTest = () => {
         </div>
       </aside>
 
-      <!-- Main Content -->
-      <div class="flex-1 flex flex-col gap-4">
-        <!-- Start Test Screen -->
-        <div v-if="!showTest" class="flex flex-col items-center justify-center h-full">
-          <h2 class="text-2xl font-bold mb-4">Willkommen zum Berufsbezogenen Rechentest</h2>
-          <p class="mb-6 text-base text-center max-w-xl">
-            In diesem Verfahren finden Sie insgesamt {{ questions.length }} Rechenaufgaben, die zu lösen sind. Hierfür haben Sie 35 Minuten Zeit. Halten Sie sich nicht zu lange an einer Aufgabe auf, wenn Sie sie nicht lösen können. Gehen Sie zur nächsten weiter.</p>
-            <p> Wir wollen wissen, auf welcher Ebene Sie mit Ihren Kenntnissen stehen und wo wir Sie individuell fördern können. </p>
-            <br>
-            <p>
-            Für Nebenrechnungen haben Sie einen zusätzlichen Block.</p>
-            <p>Bitte notieren Sie vor Abgabe Ihres Blattes Ihren Namen und das heutige Datum darauf.
-            </p>
-            
-          <Button @click="startTest" class="px-8 py-3 text-lg mt-6 font-semibold rounded-xl shadow">
+      <div class="flex flex-1 flex-col gap-4">
+        <div v-if="!showTest" class="flex h-full flex-col items-center justify-center">
+          <h2 class="mb-4 text-2xl font-bold">Willkommen zum Berufsbezogenen Rechentest</h2>
+          <p class="mb-6 max-w-xl text-center text-base">
+            In diesem Verfahren finden Sie insgesamt {{ questions.length }} Rechenaufgaben, die zu lösen sind. Hierfür haben Sie
+            35 Minuten Zeit. Halten Sie sich nicht zu lange an einer Aufgabe auf, wenn Sie sie nicht lösen können. Gehen Sie zur
+            nächsten weiter.
+          </p>
+          <p>
+            Wir wollen wissen, auf welcher Ebene Sie mit Ihren Kenntnissen stehen und wo wir Sie individuell fördern können.
+          </p>
+          <br />
+          <p>Für Nebenrechnungen haben Sie einen zusätzlichen Block.</p>
+          <p>Bitte notieren Sie vor Abgabe Ihres Blattes Ihren Namen und das heutige Datum darauf.</p>
+
+          <Button @click="startTest" class="mt-6 rounded-xl px-8 py-3 text-lg font-semibold shadow">
             Test starten
           </Button>
         </div>
 
-        <!-- Test Content -->
-        <div v-else-if="!isTestComplete && currentQuestion" class="p-6 bg-background border rounded-lg">
-          <h2 class="text-xl font-semibold mb-4">Frage {{ currentQuestionIndex + 1 }}:</h2>
-          <p class="text-lg mb-6" v-html="formatQuestionMark(currentQuestion.text)"></p>
+        <div v-else-if="!isTestComplete && currentQuestion" class="rounded-lg border bg-background p-6">
+          <h2 class="mb-4 text-xl font-semibold">Frage {{ currentQuestionIndex + 1 }}:</h2>
+          <p class="mb-6 text-lg" v-html="formatQuestionMark(currentQuestion.text)"></p>
           <div v-if="currentQuestion.image" class="mb-4">
-            <img :src="currentQuestion.image" alt="Fragebild" class="max-w-xs border rounded shadow" />
+            <img :src="currentQuestion.image" alt="Fragebild" class="max-w-xs rounded border shadow" />
           </div>
           <div class="w-full md:w-1/2">
-            <Input ref="answerInput" type="text" v-model="userAnswers[currentQuestionIndex]" placeholder="Ihre Antwort"
-              class="mb-2 w-full" />
+            <Input
+              ref="answerInput"
+              type="text"
+              v-model="userAnswers[currentQuestionIndex]"
+              placeholder="Ihre Antwort"
+              class="mb-2 w-full"
+            />
 
-            <div class="flex flex-row justify-between mt-2">
+            <div class="mt-2 flex flex-row justify-between">
               <Button @click="handlePrevClick" :disabled="currentQuestionIndex === 0" variant="outline">
                 Zurück
               </Button>
@@ -283,11 +341,11 @@ const startTest = () => {
               </Button>
             </div>
           </div>
-          <p v-if="nextButtonClickCount === 1" class="text-sm text-muted-foreground mt-2">
+          <p v-if="nextButtonClickCount === 1" class="mt-2 text-sm text-muted-foreground">
             Klicken Sie erneut auf "Weiter (Bestätigen)", um fortzufahren.
           </p>
         </div>
-        <!-- After completion show nothing (parent closes dialog) -->
+
         <div v-else-if="isTestComplete"></div>
 
         <div v-else>
@@ -295,6 +353,7 @@ const startTest = () => {
         </div>
       </div>
     </div>
+
     <Dialog v-model:open="endConfirmOpen">
       <DialogContent>
         <DialogHeader>

--- a/resources/js/pages/BRT-B.vue
+++ b/resources/js/pages/BRT-B.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3';
+import { Head } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
+import { deepClone } from '@/lib/deepClone';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -13,6 +14,17 @@ import {
 } from '@/components/ui/dialog';
 
 const emit = defineEmits(['complete']);
+
+interface BrtBProgressState {
+  started: boolean;
+  currentQuestionIndex: number;
+  nextButtonClickCount: number;
+  userAnswers: string[];
+  questionTimes: number[];
+  startTime: number | null;
+}
+
+const props = defineProps<{ initialState?: BrtBProgressState | null }>();
 
 interface Question {
   text: string;
@@ -75,18 +87,23 @@ const isLastQuestion = computed(
   () => currentQuestionIndex.value === questions.value.length - 1
 );
 
-const jumpToQuestion = (index: number) => {
-  const now = Date.now();
+const commitCurrentQuestionTime = () => {
+  const index = currentQuestionIndex.value;
   if (
-    currentQuestionIndex.value >= 0 &&
-    currentQuestionIndex.value < questions.value.length &&
-    questionStartTimestamps.value[currentQuestionIndex.value]
+    index >= 0 &&
+    index < questions.value.length &&
+    questionStartTimestamps.value[index]
   ) {
-    questionTimes.value[currentQuestionIndex.value] += Math.round(
-      (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
+    const now = Date.now();
+    questionTimes.value[index] += Math.round(
+      (now - (questionStartTimestamps.value[index] as number)) / 1000
     );
-    questionStartTimestamps.value[currentQuestionIndex.value] = null;
+    questionStartTimestamps.value[index] = null;
   }
+};
+
+const jumpToQuestion = (index: number) => {
+  commitCurrentQuestionTime();
   currentQuestionIndex.value = index;
   nextButtonClickCount.value = 0;
 };
@@ -94,17 +111,7 @@ const jumpToQuestion = (index: number) => {
 const handleNextClick = () => {
   nextButtonClickCount.value++;
   if (nextButtonClickCount.value >= 2) {
-    const now = Date.now();
-    if (
-      currentQuestionIndex.value >= 0 &&
-      currentQuestionIndex.value < questions.value.length &&
-      questionStartTimestamps.value[currentQuestionIndex.value]
-    ) {
-      questionTimes.value[currentQuestionIndex.value] += Math.round(
-        (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
-      );
-      questionStartTimestamps.value[currentQuestionIndex.value] = null;
-    }
+    commitCurrentQuestionTime();
     if (currentQuestionIndex.value < questions.value.length - 1) {
       currentQuestionIndex.value++;
       nextButtonClickCount.value = 0;
@@ -117,17 +124,7 @@ const handleNextClick = () => {
 };
 
 const handlePrevClick = () => {
-  const now = Date.now();
-  if (
-    currentQuestionIndex.value >= 0 &&
-    currentQuestionIndex.value < questions.value.length &&
-    questionStartTimestamps.value[currentQuestionIndex.value]
-  ) {
-    questionTimes.value[currentQuestionIndex.value] += Math.round(
-      (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
-    );
-    questionStartTimestamps.value[currentQuestionIndex.value] = null;
-  }
+  commitCurrentQuestionTime();
   if (currentQuestionIndex.value > 0) {
     currentQuestionIndex.value--;
     nextButtonClickCount.value = 0;
@@ -140,17 +137,7 @@ const finishTest = () => {
 };
 
 const confirmEnd = () => {
-  const now = Date.now();
-  if (
-    currentQuestionIndex.value >= 0 &&
-    currentQuestionIndex.value < questions.value.length &&
-    questionStartTimestamps.value[currentQuestionIndex.value]
-  ) {
-    questionTimes.value[currentQuestionIndex.value] += Math.round(
-      (now - (questionStartTimestamps.value[currentQuestionIndex.value] as number)) / 1000
-    );
-    questionStartTimestamps.value[currentQuestionIndex.value] = null;
-  }
+  commitCurrentQuestionTime();
   currentQuestionIndex.value = questions.value.length;
   nextButtonClickCount.value = 0;
   endConfirmOpen.value = false;
@@ -165,6 +152,65 @@ const cancelEnd = () => {
   window.dispatchEvent(new Event('cancel-finish'));
   endConfirmOpen.value = false;
 };
+
+function loadProgress(state?: BrtBProgressState | null) {
+  if (!state) return;
+
+  showTest.value = !!state.started;
+
+  const totalQuestions = questions.value.length;
+
+  const restoredAnswers = Array(totalQuestions).fill('');
+  if (Array.isArray(state.userAnswers)) {
+    state.userAnswers.slice(0, totalQuestions).forEach((answer, index) => {
+      restoredAnswers[index] = answer ?? '';
+    });
+  }
+  userAnswers.value = restoredAnswers;
+
+  const restoredTimes = Array(totalQuestions).fill(0);
+  if (Array.isArray(state.questionTimes)) {
+    state.questionTimes.slice(0, totalQuestions).forEach((time, index) => {
+      restoredTimes[index] = typeof time === 'number' ? time : 0;
+    });
+  }
+  questionTimes.value = restoredTimes;
+  questionStartTimestamps.value = Array(totalQuestions).fill(null);
+
+  nextButtonClickCount.value = state.nextButtonClickCount ?? 0;
+  startTime.value = typeof state.startTime === 'number' ? state.startTime : null;
+
+  const index = typeof state.currentQuestionIndex === 'number'
+    ? Math.min(Math.max(state.currentQuestionIndex, 0), totalQuestions)
+    : 0;
+  currentQuestionIndex.value = index;
+}
+
+function getProgress(): BrtBProgressState {
+  commitCurrentQuestionTime();
+
+  return {
+    started: showTest.value,
+    currentQuestionIndex: currentQuestionIndex.value,
+    nextButtonClickCount: nextButtonClickCount.value,
+    userAnswers: deepClone(userAnswers.value),
+    questionTimes: deepClone(questionTimes.value),
+    startTime: startTime.value,
+  };
+}
+
+watch(
+  () => props.initialState,
+  (state) => {
+    loadProgress(state ?? null);
+  },
+  { immediate: true, deep: true },
+);
+
+defineExpose({
+  getProgress,
+  loadProgress,
+});
 
 // Per-question timer starter
 watch(currentQuestionIndex, async (newIndex, oldIndex) => {
@@ -206,33 +252,40 @@ const startTest = () => {
 </script>
 
 <template>
-
-  <Head title="Tests" />
-  <div class="p-4">
-    <div class="flex justify-between items-center mb-4">
+  <div v-bind="$attrs" class="p-4">
+    <Head title="Tests" />
+    <div class="mb-4 flex items-center justify-between">
       <h1 class="text-2xl font-bold">BRT-B</h1>
     </div>
-    <div class="flex flex-1 min-h-[600px] gap-4 rounded-xl p-4 bg-muted/20">
-      <!-- Sidebar Navigation: Only visible during the test -->
-      <aside v-if="showTest" class="w-64 flex-shrink-0 flex flex-col items-start space-y-2  py-4 h-fit sticky top-8">
-        <h3 class="font-bold mb-2 text-sm text-muted-foreground pl-4">Fragen</h3>
-        <div class="flex flex-col space-y-1 w-full items-start">
+    <div class="flex min-h-[600px] flex-1 gap-4 rounded-xl bg-muted/20 p-4">
+      <aside
+        v-if="showTest"
+        class="sticky top-8 flex h-fit w-64 flex-shrink-0 flex-col items-start space-y-2 py-4"
+      >
+        <h3 class="mb-2 pl-4 text-sm font-bold text-muted-foreground">Fragen</h3>
+        <div class="flex w-full flex-col items-start space-y-1">
           <template v-for="(q, idx) in questions" :key="idx">
-            <button class="w-full flex items-center space-x-2 py-1 px-2 rounded-lg font-medium border transition
-               hover:bg-blue-50 focus:outline-none text-base" :class="{
-                'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
-                'hover:bg-blue-500': idx === currentQuestionIndex,
+            <button
+              class="flex w-full items-center space-x-2 rounded-lg border px-2 py-1 font-medium transition hover:bg-blue-50 focus:outline-none text-base"
+              :class="{
+                'bg-blue-600 text-white border-blue-600 hover:bg-blue-500': idx === currentQuestionIndex,
                 'bg-gray-300 border-gray-400 text-gray-900': userAnswers[idx] && idx !== currentQuestionIndex,
                 'bg-gray-100 border-gray-300 text-gray-900': !userAnswers[idx] && idx !== currentQuestionIndex,
-              }" @click="jumpToQuestion(idx)" :disabled="isTestComplete || !showTest">
-              <span class="w-8 h-8 flex items-center justify-center rounded-full border mr-2" :class="{
-                'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
-                'bg-gray-400 text-white border-gray-400': userAnswers[idx] && idx !== currentQuestionIndex,
-                'bg-gray-300 text-gray-600 border-gray-400': !userAnswers[idx] && idx !== currentQuestionIndex,
-              }">
+              }"
+              @click="jumpToQuestion(idx)"
+              :disabled="isTestComplete || !showTest"
+            >
+              <span
+                class="mr-2 flex h-8 w-8 items-center justify-center rounded-full border"
+                :class="{
+                  'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
+                  'bg-gray-400 text-white border-gray-400': userAnswers[idx] && idx !== currentQuestionIndex,
+                  'bg-gray-300 text-gray-600 border-gray-400': !userAnswers[idx] && idx !== currentQuestionIndex,
+                }"
+              >
                 {{ idx + 1 }}
               </span>
-              <span class="truncate max-w-[130px] text-left text-xs" :title="q.text">
+              <span class="max-w-[130px] truncate text-left text-xs" :title="q.text">
                 {{ q.text.length > 30 ? q.text.slice(0, 30) + '…' : q.text }}
               </span>
             </button>
@@ -240,37 +293,42 @@ const startTest = () => {
         </div>
       </aside>
 
-      <!-- Main Content -->
-      <div class="flex-1 flex flex-col gap-4">
-        <!-- Start Test Screen -->
-        <div v-if="!showTest" class="flex flex-col items-center justify-center h-full">
-          <h2 class="text-2xl font-bold mb-4">Willkommen zum Berufsbezogenen Rechentest</h2>
-          <p class="mb-6 text-base text-center max-w-xl">
-            In diesem Verfahren finden Sie insgesamt {{ questions.length }} Rechenaufgaben, die zu lösen sind. Hierfür haben Sie 35 Minuten Zeit. Halten Sie sich nicht zu lange an einer Aufgabe auf, wenn Sie sie nicht lösen können. Gehen Sie zur nächsten weiter.</p>
-            <p> Wir wollen wissen, auf welcher Ebene Sie mit Ihren Kenntnissen stehen und wo wir Sie individuell fördern können. </p>
-            <br>
-            <p>
-            Für Nebenrechnungen haben Sie einen zusätzlichen Block.</p>
-            <p>Bitte notieren Sie vor Abgabe Ihres Blattes Ihren Namen und das heutige Datum darauf.
-            </p>
-            
-          <Button @click="startTest" class="px-8 py-3 text-lg mt-6 font-semibold rounded-xl shadow">
+      <div class="flex flex-1 flex-col gap-4">
+        <div v-if="!showTest" class="flex h-full flex-col items-center justify-center">
+          <h2 class="mb-4 text-2xl font-bold">Willkommen zum Berufsbezogenen Rechentest</h2>
+          <p class="mb-6 max-w-xl text-center text-base">
+            In diesem Verfahren finden Sie insgesamt {{ questions.length }} Rechenaufgaben, die zu lösen sind. Hierfür haben Sie
+            35 Minuten Zeit. Halten Sie sich nicht zu lange an einer Aufgabe auf, wenn Sie sie nicht lösen können. Gehen Sie zur
+            nächsten weiter.
+          </p>
+          <p>
+            Wir wollen wissen, auf welcher Ebene Sie mit Ihren Kenntnissen stehen und wo wir Sie individuell fördern können.
+          </p>
+          <br />
+          <p>Für Nebenrechnungen haben Sie einen zusätzlichen Block.</p>
+          <p>Bitte notieren Sie vor Abgabe Ihres Blattes Ihren Namen und das heutige Datum darauf.</p>
+
+          <Button @click="startTest" class="mt-6 rounded-xl px-8 py-3 text-lg font-semibold shadow">
             Test starten
           </Button>
         </div>
 
-        <!-- Test Content -->
-        <div v-else-if="!isTestComplete && currentQuestion" class="p-6 bg-background border rounded-lg">
-          <h2 class="text-xl font-semibold mb-4">Frage {{ currentQuestionIndex + 1 }}:</h2>
-          <p class="text-lg mb-6" v-html="formatQuestionMark(currentQuestion.text)"></p>
+        <div v-else-if="!isTestComplete && currentQuestion" class="rounded-lg border bg-background p-6">
+          <h2 class="mb-4 text-xl font-semibold">Frage {{ currentQuestionIndex + 1 }}:</h2>
+          <p class="mb-6 text-lg" v-html="formatQuestionMark(currentQuestion.text)"></p>
           <div v-if="currentQuestion.image" class="mb-4">
-            <img :src="currentQuestion.image" alt="Fragebild" class="max-w-xs border rounded shadow" />
+            <img :src="currentQuestion.image" alt="Fragebild" class="max-w-xs rounded border shadow" />
           </div>
           <div class="w-full md:w-1/2">
-            <Input ref="answerInput" type="text" v-model="userAnswers[currentQuestionIndex]" placeholder="Ihre Antwort"
-              class="mb-2 w-full" />
+            <Input
+              ref="answerInput"
+              type="text"
+              v-model="userAnswers[currentQuestionIndex]"
+              placeholder="Ihre Antwort"
+              class="mb-2 w-full"
+            />
 
-            <div class="flex flex-row justify-between mt-2">
+            <div class="mt-2 flex flex-row justify-between">
               <Button @click="handlePrevClick" :disabled="currentQuestionIndex === 0" variant="outline">
                 Zurück
               </Button>
@@ -282,32 +340,33 @@ const startTest = () => {
               </Button>
             </div>
           </div>
-          <p v-if="nextButtonClickCount === 1" class="text-sm text-muted-foreground mt-2">
+          <p v-if="nextButtonClickCount === 1" class="mt-2 text-sm text-muted-foreground">
             Klicken Sie erneut auf "Weiter (Bestätigen)", um fortzufahren.
           </p>
         </div>
-        <!-- Test Results -->
+
         <div v-else-if="isTestComplete"></div>
 
-      <div v-else>
-        <p>Fragen werden geladen...</p>
+        <div v-else>
+          <p>Fragen werden geladen...</p>
+        </div>
       </div>
     </div>
+
+    <Dialog v-model:open="endConfirmOpen">
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Test beenden</DialogTitle>
+          <DialogDescription>
+            Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter class="gap-2">
+          <Button variant="secondary" @click="cancelEnd">Abbrechen</Button>
+          <Button variant="destructive" @click="confirmEnd">Ja</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   </div>
-  <Dialog v-model:open="endConfirmOpen">
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>Test beenden</DialogTitle>
-        <DialogDescription>
-          Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.
-        </DialogDescription>
-      </DialogHeader>
-      <DialogFooter class="gap-2">
-        <Button variant="secondary" @click="cancelEnd">Abbrechen</Button>
-        <Button variant="destructive" @click="confirmEnd">Ja</Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
-</div>
 </template>
 

--- a/resources/js/pages/FPI-R.vue
+++ b/resources/js/pages/FPI-R.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3';
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { Button } from '@/components/ui/button';
 import { FPI_QUESTIONS } from '@/pages/Questions/FPIQuestions';
 import {
@@ -11,10 +11,23 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
+import { deepClone } from '@/lib/deepClone';
 
 const emit = defineEmits(['complete']);
 // Settings
 const QUESTIONS_PER_BLOCK = 24;
+
+interface FpiRProgressState {
+  started: boolean;
+  consentAnswer: 'stimmt' | 'stimmtNicht' | null;
+  blockIndex: number;
+  answers: Record<number, 'stimmt' | 'stimmtNicht' | null>;
+  missedQuestions: number[];
+  finished: boolean;
+  startTime: number | null;
+}
+
+const props = defineProps<{ initialState?: FpiRProgressState | null }>();
 
 // State
 const showTest = ref(false);
@@ -119,9 +132,53 @@ function cancelEnd() {
   endConfirmOpen.value = false
 }
 
+function loadProgress(state?: FpiRProgressState | null) {
+  if (!state) return
+
+  showTest.value = !!state.started
+  consentAnswer.value = state.consentAnswer ?? null
+  blockIndex.value = typeof state.blockIndex === 'number' ? state.blockIndex : 0
+
+  if (state.answers) {
+    answers.value = { ...answers.value, ...state.answers }
+  }
+
+  missedQuestions.value = Array.isArray(state.missedQuestions)
+    ? [...state.missedQuestions]
+    : []
+
+  finished.value = !!state.finished
+  startTime.value = typeof state.startTime === 'number' ? state.startTime : null
+}
+
+function getProgress(): FpiRProgressState {
+  return {
+    started: showTest.value,
+    consentAnswer: consentAnswer.value,
+    blockIndex: blockIndex.value,
+    answers: deepClone(answers.value),
+    missedQuestions: deepClone(missedQuestions.value),
+    finished: finished.value,
+    startTime: startTime.value,
+  }
+}
+
+watch(
+  () => props.initialState,
+  (state) => {
+    loadProgress(state ?? null)
+  },
+  { immediate: true, deep: true },
+)
+
+defineExpose({
+  getProgress,
+  loadProgress,
+})
+
 // --- additions in <script setup> ---
 const isComplete = computed(() =>
-  FPI_QUESTIONS.every(q => 
+  FPI_QUESTIONS.every(q =>
   q.number === 131 || answers.value[q.number] !== null)
 )
 const remaining = computed(() =>
@@ -145,9 +202,8 @@ function finishTest() {
 </script>
 
 <template>
-
-  <Head title="FPI-R" />
-  <div class="p-4">
+  <div v-bind="$attrs" class="p-4">
+    <Head title="FPI-R" />
     <div class="flex justify-between items-center mb-4">
       <h1 class="text-2xl font-bold">FPI-R</h1>
     </div>

--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3'
-import { ref, computed } from 'vue'
+import { Head } from '@inertiajs/vue3'
+import { ref, computed, watch } from 'vue'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog'
 
 import { LMT_QUESTIONS, LMTQuestion } from '@/pages/Questions/LMTQuestions'
+import { deepClone } from '@/lib/deepClone'
 
 const normTable = {
   L1: [22, 29, 34, 37, 41, 45, 47.5, 50, 54, 58, 62, 66, 70, 76, 81],
@@ -105,12 +106,21 @@ const totalPages = computed(() =>
 
 const isTestComplete = ref(false)
 
-const page = usePage<{ auth: { user: { name: string } } }>()
-const userName = computed(() => page.props.auth?.user?.name ?? '')
 
 const emit = defineEmits(['complete'])
 
 const endConfirmOpen = ref(false)
+
+interface LmtProgressState {
+  started: boolean
+  currentPage: number
+  userAnswers: (number | null)[]
+  questionTimes: number[]
+  startTime: number | null
+  isTestComplete: boolean
+}
+
+const props = defineProps<{ initialState?: LmtProgressState | null }>()
 
 const questionsOnPage = computed(() => {
   const start = (currentPage.value - 1) * questionsPerPage
@@ -238,12 +248,75 @@ const totalTimeTaken = computed(() => {
     ? questionTimes.value.reduce((a, b) => a + b, 0)
     : null
 })
+
+function loadProgress(state?: LmtProgressState | null) {
+  if (!state) return
+
+  const totalQuestions = questions.value.length
+
+  const restoredAnswers = Array(totalQuestions).fill(null)
+  if (Array.isArray(state.userAnswers)) {
+    state.userAnswers.slice(0, totalQuestions).forEach((answer, index) => {
+      restoredAnswers[index] = typeof answer === 'number' ? answer : null
+    })
+  }
+  userAnswers.value = restoredAnswers
+
+  const restoredTimes = Array(totalQuestions).fill(0)
+  if (Array.isArray(state.questionTimes)) {
+    state.questionTimes.slice(0, totalQuestions).forEach((time, index) => {
+      restoredTimes[index] = typeof time === 'number' ? time : 0
+    })
+  }
+  questionTimes.value = restoredTimes
+  questionStartTimestamps.value = Array(totalQuestions).fill(null)
+
+  isTestComplete.value = !!state.isTestComplete
+  showTest.value = !!state.started && !isTestComplete.value
+
+  const maxPage = totalPages.value || 1
+  const page = typeof state.currentPage === 'number' ? state.currentPage : 1
+  currentPage.value = Math.min(Math.max(page, 1), maxPage)
+
+  startTime.value = typeof state.startTime === 'number' ? state.startTime : null
+
+  if (showTest.value && !isTestComplete.value) {
+    startTimingCurrentPage()
+  }
+}
+
+function getProgress(): LmtProgressState {
+  if (showTest.value && !isTestComplete.value) {
+    stopTimingCurrentPage()
+  }
+
+  return {
+    started: showTest.value,
+    currentPage: currentPage.value,
+    userAnswers: deepClone(userAnswers.value),
+    questionTimes: deepClone(questionTimes.value),
+    startTime: startTime.value,
+    isTestComplete: isTestComplete.value,
+  }
+}
+
+watch(
+  () => props.initialState,
+  (state) => {
+    loadProgress(state ?? null)
+  },
+  { immediate: true, deep: true },
+)
+
+defineExpose({
+  getProgress,
+  loadProgress,
+})
 </script>
 
 <template>
-
-  <Head title="LMT" />
-  <div class="p-4">
+  <div v-bind="$attrs" class="p-4">
+    <Head title="LMT" />
     <div class="flex justify-between items-center mb-4">
       <h1 class="text-2xl font-bold">L-M-T</h1>
     </div>

--- a/resources/js/pages/MRT-A.vue
+++ b/resources/js/pages/MRT-A.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Head, usePage } from '@inertiajs/vue3';
-import { ref, computed, watch, nextTick } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import MrtAResult from '@/components/MrtAResult.vue';
 import { useMrtA } from '@/composables/useMrtA';
+import { deepClone } from '@/lib/deepClone';
 
 const { mrtQuestions, calculateScores } = useMrtA();
 
@@ -25,7 +26,6 @@ const page = usePage<{
     };
   };
 }>();
-const userName = computed(() => page.props.auth?.user?.name ?? '');
 const profile = computed(() => page.props.auth?.user?.participant_profile);
 const userAge = computed<number | null>(() => {
   const age = profile.value?.age;
@@ -40,11 +40,38 @@ const showTest = ref(false);
 const currentQuestionIndex = ref(0);
 const isLastQuestion = computed(() => currentQuestionIndex.value === mrtQuestions.length - 1);
 
+interface MrtAProgressState {
+  started: boolean;
+  currentQuestionIndex: number;
+  userAnswers: (string | null)[];
+  questionTimes: number[];
+  tempSelected: (string | null)[];
+  tempClickState: boolean[];
+  startTime: number | null;
+  showResults: boolean;
+}
+
+const props = defineProps<{ initialState?: MrtAProgressState | null }>();
+
 // --- For per-question state:
 const userAnswers = ref<(string | null)[]>(Array(mrtQuestions.length).fill(null));
 const questionTimes = ref<number[]>(Array(mrtQuestions.length).fill(0));
 const questionStartTimestamps = ref<(number | null)[]>(Array(mrtQuestions.length).fill(null));
 const startTime = ref<number | null>(null);
+
+const commitQuestionTime = (index: number) => {
+  if (
+    index >= 0 &&
+    index < mrtQuestions.length &&
+    questionStartTimestamps.value[index]
+  ) {
+    const now = Date.now();
+    questionTimes.value[index] += Math.round(
+      (now - (questionStartTimestamps.value[index] as number)) / 1000
+    );
+    questionStartTimestamps.value[index] = null;
+  }
+};
 
 const isTestComplete = computed(() => currentQuestionIndex.value >= mrtQuestions.length);
 
@@ -80,17 +107,7 @@ const handleOptionClick = (optIdx: number) => {
     tempSelected.value[qidx] = null;
 
     // --- After confirming, record time and auto-jump ---
-    const now = Date.now();
-    if (
-      qidx >= 0 &&
-      qidx < mrtQuestions.length &&
-      questionStartTimestamps.value[qidx]
-    ) {
-      questionTimes.value[qidx] += Math.round(
-        (now - (questionStartTimestamps.value[qidx] as number)) / 1000
-      );
-      questionStartTimestamps.value[qidx] = null;
-    }
+    commitQuestionTime(qidx);
     if (currentQuestionIndex.value < mrtQuestions.length - 1) {
       currentQuestionIndex.value++;
     }
@@ -103,36 +120,16 @@ const handleOptionClick = (optIdx: number) => {
 
 
 const handleNextClick = () => {
-  const now = Date.now();
   const qidx = currentQuestionIndex.value;
-  if (
-    qidx >= 0 &&
-    qidx < mrtQuestions.length &&
-    questionStartTimestamps.value[qidx]
-  ) {
-    questionTimes.value[qidx] += Math.round(
-      (now - (questionStartTimestamps.value[qidx] as number)) / 1000
-    );
-    questionStartTimestamps.value[qidx] = null;
-  }
+  commitQuestionTime(qidx);
   if (currentQuestionIndex.value < mrtQuestions.length - 1) {
     currentQuestionIndex.value++;
   }
 };
 
 const handlePrevClick = () => {
-  const now = Date.now();
   const qidx = currentQuestionIndex.value;
-  if (
-    qidx >= 0 &&
-    qidx < mrtQuestions.length &&
-    questionStartTimestamps.value[qidx]
-  ) {
-    questionTimes.value[qidx] += Math.round(
-      (now - (questionStartTimestamps.value[qidx] as number)) / 1000
-    );
-    questionStartTimestamps.value[qidx] = null;
-  }
+  commitQuestionTime(qidx);
   if (currentQuestionIndex.value > 0) {
     currentQuestionIndex.value--;
   }
@@ -148,19 +145,86 @@ const cancelEnd = () => {
   endConfirmOpen.value = false;
 };
 
-const confirmEnd = () => {
-  const now = Date.now();
-  const qidx = currentQuestionIndex.value;
-  if (
-    qidx >= 0 &&
-    qidx < mrtQuestions.length &&
-    questionStartTimestamps.value[qidx]
-  ) {
-    questionTimes.value[qidx] += Math.round(
-      (now - (questionStartTimestamps.value[qidx] as number)) / 1000
-    );
-    questionStartTimestamps.value[qidx] = null;
+function loadProgress(state?: MrtAProgressState | null) {
+  if (!state) return;
+
+  const totalQuestions = mrtQuestions.length;
+
+  const restoredAnswers = Array(totalQuestions).fill(null);
+  if (Array.isArray(state.userAnswers)) {
+    state.userAnswers.slice(0, totalQuestions).forEach((answer, index) => {
+      restoredAnswers[index] = typeof answer === 'string' ? answer : null;
+    });
   }
+  userAnswers.value = restoredAnswers;
+
+  const restoredTimes = Array(totalQuestions).fill(0);
+  if (Array.isArray(state.questionTimes)) {
+    state.questionTimes.slice(0, totalQuestions).forEach((time, index) => {
+      restoredTimes[index] = typeof time === 'number' ? time : 0;
+    });
+  }
+  questionTimes.value = restoredTimes;
+  questionStartTimestamps.value = Array(totalQuestions).fill(null);
+
+  const restoredTempSelected = Array(totalQuestions).fill(null);
+  if (Array.isArray(state.tempSelected)) {
+    state.tempSelected.slice(0, totalQuestions).forEach((value, index) => {
+      restoredTempSelected[index] = typeof value === 'string' ? value : null;
+    });
+  }
+  tempSelected.value = restoredTempSelected;
+
+  const restoredTempClickState = Array(totalQuestions).fill(false);
+  if (Array.isArray(state.tempClickState)) {
+    state.tempClickState.slice(0, totalQuestions).forEach((value, index) => {
+      restoredTempClickState[index] = !!value;
+    });
+  }
+  tempClickState.value = restoredTempClickState;
+
+  startTime.value = typeof state.startTime === 'number' ? state.startTime : null;
+
+  showResults.value = !!state.showResults;
+  showTest.value = !!state.started && !showResults.value;
+
+  const index = typeof state.currentQuestionIndex === 'number'
+    ? Math.min(Math.max(state.currentQuestionIndex, 0), totalQuestions)
+    : 0;
+  currentQuestionIndex.value = index;
+}
+
+function getProgress(): MrtAProgressState {
+  commitQuestionTime(currentQuestionIndex.value);
+
+  return {
+    started: showTest.value,
+    currentQuestionIndex: currentQuestionIndex.value,
+    userAnswers: deepClone(userAnswers.value),
+    questionTimes: deepClone(questionTimes.value),
+    tempSelected: deepClone(tempSelected.value),
+    tempClickState: deepClone(tempClickState.value),
+    startTime: startTime.value,
+    showResults: showResults.value,
+  };
+}
+
+watch(
+  () => props.initialState,
+  (state) => {
+    loadProgress(state ?? null);
+  },
+  { immediate: true, deep: true },
+);
+
+defineExpose({
+  getProgress,
+  loadProgress,
+});
+
+const confirmEnd = () => {
+  const qidx = currentQuestionIndex.value;
+  commitQuestionTime(qidx);
   currentQuestionIndex.value = mrtQuestions.length;
   endConfirmOpen.value = false;
   showResults.value = true;
@@ -185,7 +249,7 @@ const calculatedResults = computed(() => {
   };
 });
 
-watch(currentQuestionIndex, async (newIndex, oldIndex) => {
+watch(currentQuestionIndex, async (newIndex) => {
   const now = Date.now();
   if (
     typeof newIndex === 'number' &&
@@ -218,9 +282,8 @@ const startTest = () => {
 </script>
 
 <template>
-
-  <Head title="Tests" />
-  <div class="p-4">
+  <div v-bind="$attrs" class="p-4">
+    <Head title="Tests" />
     <div class="flex justify-between items-center mb-4">
       <h1 class="text-2xl font-bold">MRT-A</h1>
     </div>

--- a/resources/js/pages/MRT-B.vue
+++ b/resources/js/pages/MRT-B.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Head, usePage } from '@inertiajs/vue3';
-import { ref, computed, watch, nextTick } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import MrtBResult from '@/components/MrtBResult.vue';
 import { useMrtB } from '@/composables/useMrtB';
+import { deepClone } from '@/lib/deepClone';
 
 const { mrtQuestions, calculateScores } = useMrtB();
 
@@ -25,7 +26,6 @@ const page = usePage<{
     };
   };
 }>();
-const userName = computed(() => page.props.auth?.user?.name ?? '');
 const profile = computed(() => page.props.auth?.user?.participant_profile);
 const userAge = computed<number | null>(() => {
   const age = profile.value?.age;
@@ -39,6 +39,19 @@ const showResults = ref(false);
 const showTest = ref(false);
 const currentQuestionIndex = ref(0);
 const isLastQuestion = computed(() => currentQuestionIndex.value === mrtQuestions.length - 1);
+
+interface MrtBProgressState {
+  started: boolean;
+  currentQuestionIndex: number;
+  userAnswers: (string | null)[];
+  questionTimes: number[];
+  tempSelected: (string | null)[];
+  tempClickState: boolean[];
+  startTime: number | null;
+  showResults: boolean;
+}
+
+const props = defineProps<{ initialState?: MrtBProgressState | null }>();
 
 // --- For per-question state:
 const userAnswers = ref<(string | null)[]>(Array(mrtQuestions.length).fill(null));
@@ -80,17 +93,7 @@ const handleOptionClick = (optIdx: number) => {
     tempSelected.value[qidx] = null;
 
     // --- After confirming, record time and auto-jump ---
-    const now = Date.now();
-    if (
-      qidx >= 0 &&
-      qidx < mrtQuestions.length &&
-      questionStartTimestamps.value[qidx]
-    ) {
-      questionTimes.value[qidx] += Math.round(
-        (now - (questionStartTimestamps.value[qidx] as number)) / 1000
-      );
-      questionStartTimestamps.value[qidx] = null;
-    }
+    commitQuestionTime(qidx);
     if (currentQuestionIndex.value < mrtQuestions.length - 1) {
       currentQuestionIndex.value++;
     }
@@ -103,36 +106,16 @@ const handleOptionClick = (optIdx: number) => {
 
 
 const handleNextClick = () => {
-  const now = Date.now();
   const qidx = currentQuestionIndex.value;
-  if (
-    qidx >= 0 &&
-    qidx < mrtQuestions.length &&
-    questionStartTimestamps.value[qidx]
-  ) {
-    questionTimes.value[qidx] += Math.round(
-      (now - (questionStartTimestamps.value[qidx] as number)) / 1000
-    );
-    questionStartTimestamps.value[qidx] = null;
-  }
+  commitQuestionTime(qidx);
   if (currentQuestionIndex.value < mrtQuestions.length - 1) {
     currentQuestionIndex.value++;
   }
 };
 
 const handlePrevClick = () => {
-  const now = Date.now();
   const qidx = currentQuestionIndex.value;
-  if (
-    qidx >= 0 &&
-    qidx < mrtQuestions.length &&
-    questionStartTimestamps.value[qidx]
-  ) {
-    questionTimes.value[qidx] += Math.round(
-      (now - (questionStartTimestamps.value[qidx] as number)) / 1000
-    );
-    questionStartTimestamps.value[qidx] = null;
-  }
+  commitQuestionTime(qidx);
   if (currentQuestionIndex.value > 0) {
     currentQuestionIndex.value--;
   }
@@ -148,19 +131,86 @@ const cancelEnd = () => {
   endConfirmOpen.value = false;
 };
 
-const confirmEnd = () => {
-  const now = Date.now();
-  const qidx = currentQuestionIndex.value;
-  if (
-    qidx >= 0 &&
-    qidx < mrtQuestions.length &&
-    questionStartTimestamps.value[qidx]
-  ) {
-    questionTimes.value[qidx] += Math.round(
-      (now - (questionStartTimestamps.value[qidx] as number)) / 1000
-    );
-    questionStartTimestamps.value[qidx] = null;
+function loadProgress(state?: MrtBProgressState | null) {
+  if (!state) return;
+
+  const totalQuestions = mrtQuestions.length;
+
+  const restoredAnswers = Array(totalQuestions).fill(null);
+  if (Array.isArray(state.userAnswers)) {
+    state.userAnswers.slice(0, totalQuestions).forEach((answer, index) => {
+      restoredAnswers[index] = typeof answer === 'string' ? answer : null;
+    });
   }
+  userAnswers.value = restoredAnswers;
+
+  const restoredTimes = Array(totalQuestions).fill(0);
+  if (Array.isArray(state.questionTimes)) {
+    state.questionTimes.slice(0, totalQuestions).forEach((time, index) => {
+      restoredTimes[index] = typeof time === 'number' ? time : 0;
+    });
+  }
+  questionTimes.value = restoredTimes;
+  questionStartTimestamps.value = Array(totalQuestions).fill(null);
+
+  const restoredTempSelected = Array(totalQuestions).fill(null);
+  if (Array.isArray(state.tempSelected)) {
+    state.tempSelected.slice(0, totalQuestions).forEach((value, index) => {
+      restoredTempSelected[index] = typeof value === 'string' ? value : null;
+    });
+  }
+  tempSelected.value = restoredTempSelected;
+
+  const restoredTempClickState = Array(totalQuestions).fill(false);
+  if (Array.isArray(state.tempClickState)) {
+    state.tempClickState.slice(0, totalQuestions).forEach((value, index) => {
+      restoredTempClickState[index] = !!value;
+    });
+  }
+  tempClickState.value = restoredTempClickState;
+
+  startTime.value = typeof state.startTime === 'number' ? state.startTime : null;
+
+  showResults.value = !!state.showResults;
+  showTest.value = !!state.started && !showResults.value;
+
+  const index = typeof state.currentQuestionIndex === 'number'
+    ? Math.min(Math.max(state.currentQuestionIndex, 0), totalQuestions)
+    : 0;
+  currentQuestionIndex.value = index;
+}
+
+function getProgress(): MrtBProgressState {
+  commitQuestionTime(currentQuestionIndex.value);
+
+  return {
+    started: showTest.value,
+    currentQuestionIndex: currentQuestionIndex.value,
+    userAnswers: deepClone(userAnswers.value),
+    questionTimes: deepClone(questionTimes.value),
+    tempSelected: deepClone(tempSelected.value),
+    tempClickState: deepClone(tempClickState.value),
+    startTime: startTime.value,
+    showResults: showResults.value,
+  };
+}
+
+watch(
+  () => props.initialState,
+  (state) => {
+    loadProgress(state ?? null);
+  },
+  { immediate: true, deep: true },
+);
+
+defineExpose({
+  getProgress,
+  loadProgress,
+});
+
+const confirmEnd = () => {
+  const qidx = currentQuestionIndex.value;
+  commitQuestionTime(qidx);
   currentQuestionIndex.value = mrtQuestions.length;
   endConfirmOpen.value = false;
   showResults.value = true;
@@ -185,7 +235,7 @@ const calculatedResults = computed(() => {
   };
 });
 
-watch(currentQuestionIndex, async (newIndex, oldIndex) => {
+watch(currentQuestionIndex, async (newIndex) => {
   const now = Date.now();
   if (
     typeof newIndex === 'number' &&
@@ -218,9 +268,8 @@ const startTest = () => {
 </script>
 
 <template>
-
-  <Head title="Tests" />
-  <div class="p-4">
+  <div v-bind="$attrs" class="p-4">
+    <Head title="Tests" />
     <div class="flex justify-between items-center mb-4">
       <h1 class="text-2xl font-bold">MRT-B</h1>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/my-exam/start-step', [ParticipantController::class, 'startStep'])->name('my-exam.start-step');
     Route::post('/my-exam/complete-step', [ParticipantController::class, 'completeStep'])->name('my-exam.complete-step');
     Route::post('/my-exam/break-step', [ParticipantController::class, 'breakStep'])->name('my-exam.break-step');
+    Route::post('/my-exam/save-progress', [ParticipantController::class, 'saveProgress'])->name('my-exam.save-progress');
 
     // Exam management (teacher/admin only, add middleware if needed)
     Route::post('/exam-step-status/{status}/add-time', [ExamStepStatusController::class, 'addTime'])->name('exam-step-status.add-time');


### PR DESCRIPTION
## Summary
- keep the latest captured test progress snapshot so breaking out of the dialog still sends saved answers and pauses the step
- reapply saved attempt state to the mounted test component so "Fortsetzen" resumes where the participant left off

## Testing
- `npm run lint` *(fails: existing unused-variable and template warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c90a483d848329be34b46f07a84c57