### PR TITLE
Add participant pause controls to live exam dashboard

### DIFF
--- a/app/Models/ExamStepStatus.php
+++ b/app/Models/ExamStepStatus.php
@@ -11,8 +11,10 @@ class ExamStepStatus extends Model
     'participant_id',
     'exam_step_id',
     'status',
+    'paused_from_status',
     'duration',
     'extra_time',
+    'time_remaining_seconds',
     'started_at',
     'completed_at'
   ];

--- a/database/migrations/2025_08_01_081700_add_pause_fields_to_exam_step_statuses_table.php
+++ b/database/migrations/2025_08_01_081700_add_pause_fields_to_exam_step_statuses_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('exam_step_statuses', function (Blueprint $table) {
+            $table->integer('time_remaining_seconds')->nullable()->after('grace_period_seconds');
+            $table->string('paused_from_status')->nullable()->after('status');
+        });
+
+        if (Schema::getConnection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE `exam_step_statuses` MODIFY COLUMN `status` ENUM('not_started','in_progress','waiting','paused','completed','broken') DEFAULT 'not_started'");
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::getConnection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE `exam_step_statuses` MODIFY COLUMN `status` ENUM('not_started','in_progress','waiting','completed') DEFAULT 'not_started'");
+        }
+
+        Schema::table('exam_step_statuses', function (Blueprint $table) {
+            $table->dropColumn(['time_remaining_seconds', 'paused_from_status']);
+        });
+    }
+};

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -18,7 +18,7 @@ import MRTA from '@/pages/MRT-A.vue';
 import MRTB from '@/pages/MRT-B.vue';
 import KONZ from '@/pages/Konzentrationstest.vue';
 
-type StepStatus = 'not_started' | 'in_progress' | 'completed' | 'broken';
+type StepStatus = 'not_started' | 'in_progress' | 'completed' | 'broken' | 'paused';
 type ExamStatus = 'not_started' | 'in_progress' | 'paused' | 'completed';
 
 const props = defineProps<{
@@ -50,6 +50,9 @@ const isTestDialogOpen = ref(false);
 const activeStepId = ref<number | null>(null);
 const page = usePage();
 const userName = computed(() => page.props.auth?.user?.name);
+const hasPausedStep = computed(() =>
+    Object.values(props.stepStatuses || {}).some((status) => status?.status === 'paused'),
+);
 
 const testComponents = {
     'BRT-A': BRTA,
@@ -70,6 +73,7 @@ function getStatusText(status: StepStatus) {
         in_progress: 'In Bearbeitung',
         completed: 'Abgeschlossen',
         broken: 'Abgebrochen',
+        paused: 'Pausiert',
     } as const;
     return map[status];
 }
@@ -212,6 +216,12 @@ onUnmounted(() => {
             <!-- Exam Steps Table -->
             <div v-else class="space-y-4">
                 <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-200">Testübersicht</h2>
+                <div
+                    v-if="hasPausedStep"
+                    class="rounded-md border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-700 dark:border-yellow-400/40 dark:bg-yellow-950/40 dark:text-yellow-100"
+                >
+                    Der Prüfer hat Ihren aktuellen Test pausiert. Bitte warten Sie auf weitere Anweisungen.
+                </div>
                 <div class="mt-4 overflow-hidden rounded-lg bg-white shadow-sm dark:bg-gray-800">
                     <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                         <thead class="bg-gray-50 dark:bg-gray-700">
@@ -246,6 +256,10 @@ onUnmounted(() => {
                                                     'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
                                                 stepStatuses[step.id]?.status === 'not_started' &&
                                                     'bg-gray-100 text-gray-800 dark:bg-gray-600 dark:text-gray-200',
+                                                stepStatuses[step.id]?.status === 'paused' &&
+                                                    'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+                                                stepStatuses[step.id]?.status === 'broken' &&
+                                                    'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
                                             )
                                         "
                                     >

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,8 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/exams/{exam}/next-step', [ExamController::class, 'nextStep'])->name('exams.next-step');
     Route::post('/exams/{exam}/set-status', [ExamController::class, 'setStatus'])->name('exams.set-status');
     Route::post('/exams/{exam}/set-step', [ExamController::class, 'setStep'])->name('exams.set-step');
+    Route::post('/exams/{exam}/participants/{participant}/step-status', [ExamController::class, 'setParticipantStepStatus'])
+        ->name('exams.participants.set-step-status');
 
     Route::post('/exams', [ExamController::class, 'store'])->name('exams.store');
     Route::post('/exams/store-with-participants', [ExamController::class, 'storeWithParticipants'])->name('exams.storeWithParticipants');


### PR DESCRIPTION
## Summary
- add database support for per-participant pause state and time tracking on exam steps
- expose an endpoint and dashboard controls for pausing or resuming individual examinees
- surface paused status and messaging in the exam room UI for affected participants

## Testing
- php artisan test *(fails: missing vendor autoload because composer install requires GitHub token)*
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c938fe7c248329b1e09df305b4ab8a