### PR TITLE
Fix dialog warnings and forward class attributes

### DIFF
--- a/resources/js/components/ui/dialog/DialogContent.vue
+++ b/resources/js/components/ui/dialog/DialogContent.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { cn } from '@/lib/utils'
+import { reactiveOmit } from '@vueuse/core'
 import { X } from 'lucide-vue-next'
 import {
   DialogClose,
@@ -9,17 +10,13 @@ import {
   DialogPortal,
   useForwardPropsEmits,
 } from 'reka-ui'
-import { computed, type HTMLAttributes } from 'vue'
+import { type HTMLAttributes } from 'vue'
 import DialogOverlay from './DialogOverlay.vue'
 
 const props = defineProps<DialogContentProps & { class?: HTMLAttributes['class'] }>()
 const emits = defineEmits<DialogContentEmits>()
 
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, 'class')
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/resources/js/components/ui/dialog/DialogScrollContent.vue
+++ b/resources/js/components/ui/dialog/DialogScrollContent.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { cn } from '@/lib/utils'
+import { reactiveOmit } from '@vueuse/core'
 import { X } from 'lucide-vue-next'
 import {
   DialogClose,
@@ -10,16 +11,12 @@ import {
   DialogPortal,
   useForwardPropsEmits,
 } from 'reka-ui'
-import { computed, type HTMLAttributes } from 'vue'
+import { type HTMLAttributes } from 'vue'
 
 const props = defineProps<DialogContentProps & { class?: HTMLAttributes['class'] }>()
 const emits = defineEmits<DialogContentEmits>()
 
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, 'class')
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3';
+import { Head } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -207,107 +207,121 @@ const startTest = () => {
 </script>
 
 <template>
+  <div>
+    <Head title="Tests" />
+    <div class="p-4">
+      <div class="flex justify-between items-center mb-4">
+        <h1 class="text-2xl font-bold">BRT-A</h1>
+      </div>
+      <div class="flex flex-1 min-h-[600px] gap-4 rounded-xl p-4 bg-muted/20">
+        <!-- Sidebar Navigation: Only visible during the test -->
+        <aside v-if="showTest" class="w-64 flex-shrink-0 flex flex-col items-start space-y-2  py-4 h-fit sticky top-8">
+          <h3 class="font-bold mb-2 text-sm text-muted-foreground pl-4">Fragen</h3>
+          <div class="flex flex-col space-y-1 w-full items-start">
+            <template v-for="(q, idx) in questions" :key="idx">
+              <button
+                class="w-full flex items-center space-x-2 py-1 px-2 rounded-lg font-medium border transition hover:bg-blue-50 focus:outline-none text-base"
+                :class="{
+                  'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
+                  'hover:bg-blue-500': idx === currentQuestionIndex,
+                  'bg-gray-300 border-gray-400 text-gray-900': userAnswers[idx] && idx !== currentQuestionIndex,
+                  'bg-gray-100 border-gray-300 text-gray-900': !userAnswers[idx] && idx !== currentQuestionIndex,
+                }"
+                @click="jumpToQuestion(idx)"
+                :disabled="isTestComplete || !showTest"
+              >
+                <span
+                  class="w-8 h-8 flex items-center justify-center rounded-full border mr-2"
+                  :class="{
+                    'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
+                    'bg-gray-400 text-white border-gray-400': userAnswers[idx] && idx !== currentQuestionIndex,
+                    'bg-gray-300 text-gray-600 border-gray-400': !userAnswers[idx] && idx !== currentQuestionIndex,
+                  }"
+                >
+                  {{ idx + 1 }}
+                </span>
+                <span class="truncate max-w-[130px] text-left text-xs" :title="q.text">
+                  {{ q.text.length > 30 ? q.text.slice(0, 30) + '…' : q.text }}
+                </span>
+              </button>
+            </template>
+          </div>
+        </aside>
 
-  <Head title="Tests" />
-  <div class="p-4">
-    <div class="flex justify-between items-center mb-4">
-      <h1 class="text-2xl font-bold">BRT-A</h1>
-    </div>
-    <div class="flex flex-1 min-h-[600px] gap-4 rounded-xl p-4 bg-muted/20">
-      <!-- Sidebar Navigation: Only visible during the test -->
-      <aside v-if="showTest" class="w-64 flex-shrink-0 flex flex-col items-start space-y-2  py-4 h-fit sticky top-8">
-        <h3 class="font-bold mb-2 text-sm text-muted-foreground pl-4">Fragen</h3>
-        <div class="flex flex-col space-y-1 w-full items-start">
-          <template v-for="(q, idx) in questions" :key="idx">
-            <button class="w-full flex items-center space-x-2 py-1 px-2 rounded-lg font-medium border transition
-               hover:bg-blue-50 focus:outline-none text-base" :class="{
-                'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
-                'hover:bg-blue-500': idx === currentQuestionIndex,
-                'bg-gray-300 border-gray-400 text-gray-900': userAnswers[idx] && idx !== currentQuestionIndex,
-                'bg-gray-100 border-gray-300 text-gray-900': !userAnswers[idx] && idx !== currentQuestionIndex,
-              }" @click="jumpToQuestion(idx)" :disabled="isTestComplete || !showTest">
-              <span class="w-8 h-8 flex items-center justify-center rounded-full border mr-2" :class="{
-                'bg-blue-600 text-white border-blue-600': idx === currentQuestionIndex,
-                'bg-gray-400 text-white border-gray-400': userAnswers[idx] && idx !== currentQuestionIndex,
-                'bg-gray-300 text-gray-600 border-gray-400': !userAnswers[idx] && idx !== currentQuestionIndex,
-              }">
-                {{ idx + 1 }}
-              </span>
-              <span class="truncate max-w-[130px] text-left text-xs" :title="q.text">
-                {{ q.text.length > 30 ? q.text.slice(0, 30) + '…' : q.text }}
-              </span>
-            </button>
-          </template>
-        </div>
-      </aside>
-
-      <!-- Main Content -->
-      <div class="flex-1 flex flex-col gap-4">
-        <!-- Start Test Screen -->
-        <div v-if="!showTest" class="flex flex-col items-center justify-center h-full">
-          <h2 class="text-2xl font-bold mb-4">Willkommen zum Berufsbezogenen Rechentest</h2>
-          <p class="mb-6 text-base text-center max-w-xl">
-            In diesem Verfahren finden Sie insgesamt {{ questions.length }} Rechenaufgaben, die zu lösen sind. Hierfür haben Sie 35 Minuten Zeit. Halten Sie sich nicht zu lange an einer Aufgabe auf, wenn Sie sie nicht lösen können. Gehen Sie zur nächsten weiter.</p>
-            <p> Wir wollen wissen, auf welcher Ebene Sie mit Ihren Kenntnissen stehen und wo wir Sie individuell fördern können. </p>
-            <br>
-            <p>
-            Für Nebenrechnungen haben Sie einen zusätzlichen Block.</p>
-            <p>Bitte notieren Sie vor Abgabe Ihres Blattes Ihren Namen und das heutige Datum darauf.
+        <!-- Main Content -->
+        <div class="flex-1 flex flex-col gap-4">
+          <!-- Start Test Screen -->
+          <div v-if="!showTest" class="flex flex-col items-center justify-center h-full">
+            <h2 class="text-2xl font-bold mb-4">Willkommen zum Berufsbezogenen Rechentest</h2>
+            <p class="mb-6 text-base text-center max-w-xl">
+              In diesem Verfahren finden Sie insgesamt {{ questions.length }} Rechenaufgaben, die zu lösen sind. Hierfür haben Sie
+              35 Minuten Zeit. Halten Sie sich nicht zu lange an einer Aufgabe auf, wenn Sie sie nicht lösen können. Gehen Sie zur
+              nächsten weiter.
             </p>
-            
-          <Button @click="startTest" class="px-8 py-3 text-lg mt-6 font-semibold rounded-xl shadow">
-            Test starten
-          </Button>
-        </div>
+            <p>Wir wollen wissen, auf welcher Ebene Sie mit Ihren Kenntnissen stehen und wo wir Sie individuell fördern können.</p>
+            <br />
+            <p>Für Nebenrechnungen haben Sie einen zusätzlichen Block.</p>
+            <p>Bitte notieren Sie vor Abgabe Ihres Blattes Ihren Namen und das heutige Datum darauf.</p>
 
-        <!-- Test Content -->
-        <div v-else-if="!isTestComplete && currentQuestion" class="p-6 bg-background border rounded-lg">
-          <h2 class="text-xl font-semibold mb-4">Frage {{ currentQuestionIndex + 1 }}:</h2>
-          <p class="text-lg mb-6" v-html="formatQuestionMark(currentQuestion.text)"></p>
-          <div v-if="currentQuestion.image" class="mb-4">
-            <img :src="currentQuestion.image" alt="Fragebild" class="max-w-xs border rounded shadow" />
+            <Button @click="startTest" class="px-8 py-3 text-lg mt-6 font-semibold rounded-xl shadow">
+              Test starten
+            </Button>
           </div>
-          <div class="w-full md:w-1/2">
-            <Input ref="answerInput" type="text" v-model="userAnswers[currentQuestionIndex]" placeholder="Ihre Antwort"
-              class="mb-2 w-full" />
 
-            <div class="flex flex-row justify-between mt-2">
-              <Button @click="handlePrevClick" :disabled="currentQuestionIndex === 0" variant="outline">
-                Zurück
-              </Button>
-              <Button v-if="isLastQuestion" @click="finishTest" variant="destructive">
-                Test beenden
-              </Button>
-              <Button v-else @click="handleNextClick">
-                {{ nextButtonText }}
-              </Button>
+          <!-- Test Content -->
+          <div v-else-if="!isTestComplete && currentQuestion" class="p-6 bg-background border rounded-lg">
+            <h2 class="text-xl font-semibold mb-4">Frage {{ currentQuestionIndex + 1 }}:</h2>
+            <p class="text-lg mb-6" v-html="formatQuestionMark(currentQuestion.text)"></p>
+            <div v-if="currentQuestion.image" class="mb-4">
+              <img :src="currentQuestion.image" alt="Fragebild" class="max-w-xs border rounded shadow" />
             </div>
-          </div>
-          <p v-if="nextButtonClickCount === 1" class="text-sm text-muted-foreground mt-2">
-            Klicken Sie erneut auf "Weiter (Bestätigen)", um fortzufahren.
-          </p>
-        </div>
-        <!-- After completion show nothing (parent closes dialog) -->
-        <div v-else-if="isTestComplete"></div>
+            <div class="w-full md:w-1/2">
+              <Input
+                ref="answerInput"
+                type="text"
+                v-model="userAnswers[currentQuestionIndex]"
+                placeholder="Ihre Antwort"
+                class="mb-2 w-full"
+              />
 
-        <div v-else>
-          <p>Fragen werden geladen...</p>
+              <div class="flex flex-row justify-between mt-2">
+                <Button @click="handlePrevClick" :disabled="currentQuestionIndex === 0" variant="outline">
+                  Zurück
+                </Button>
+                <Button v-if="isLastQuestion" @click="finishTest" variant="destructive">
+                  Test beenden
+                </Button>
+                <Button v-else @click="handleNextClick">
+                  {{ nextButtonText }}
+                </Button>
+              </div>
+            </div>
+            <p v-if="nextButtonClickCount === 1" class="text-sm text-muted-foreground mt-2">
+              Klicken Sie erneut auf "Weiter (Bestätigen)", um fortzufahren.
+            </p>
+          </div>
+          <!-- After completion show nothing (parent closes dialog) -->
+          <div v-else-if="isTestComplete"></div>
+
+          <div v-else>
+            <p>Fragen werden geladen...</p>
+          </div>
         </div>
       </div>
+      <Dialog v-model:open="endConfirmOpen">
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Test beenden</DialogTitle>
+            <DialogDescription>
+              Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter class="gap-2">
+            <Button variant="secondary" @click="cancelEnd">Abbrechen</Button>
+            <Button variant="destructive" @click="confirmEnd">Ja</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
-    <Dialog v-model:open="endConfirmOpen">
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Test beenden</DialogTitle>
-          <DialogDescription>
-            Sind Sie sicher, dass Sie den Test beenden möchten? Es gibt kein Zurück.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter class="gap-2">
-          <Button variant="secondary" @click="cancelEnd">Abbrechen</Button>
-          <Button variant="destructive" @click="confirmEnd">Ja</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   </div>
 </template>

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -51,6 +51,19 @@ const userName = computed(() => page.props.auth?.user?.name);
 const activeTestComponent = shallowRef<unknown>(null);
 const isTestDialogOpen = ref(false);
 const activeStepId = ref<number | null>(null);
+const activeStep = computed(() => {
+    if (activeStepId.value === null) {
+        return null;
+    }
+
+    return props.exam.steps.find((step) => step.id === activeStepId.value) ?? null;
+});
+const activeTestTitle = computed(() => activeStep.value?.test.name ?? 'Aktiver Test');
+const activeTestDescription = computed(() =>
+    activeStep.value
+        ? `In diesem Dialog bearbeiten Sie den Test ${activeStep.value.test.name}.`
+        : 'In diesem Dialog bearbeiten Sie den aktuellen Test.',
+);
 
 const testComponents: Record<string, unknown> = {
     'BRT-A': BRTA,
@@ -469,6 +482,10 @@ watch(
                                             <template #top-right>
                                                 <div class="absolute top-4 right-4 font-semibold">{{ userName }}</div>
                                             </template>
+                                            <DialogHeader class="sr-only">
+                                                <DialogTitle>{{ activeTestTitle }}</DialogTitle>
+                                                <DialogDescription>{{ activeTestDescription }}</DialogDescription>
+                                            </DialogHeader>
                                             <KeepAlive>
                                                 <component
                                                     v-if="activeTestComponent"


### PR DESCRIPTION
## Summary
- forward reactive dialog props to remove toRefs warnings in custom dialog wrappers
- wrap the BRT-A page in a single root element so parent classes apply cleanly
- add accessible dialog header metadata when launching full-screen tests

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7800593483299be3dd0efdf034fb