### PR TITLE
Capture participant progress on pauses

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -10,6 +10,7 @@ use App\Models\Employed;
 use App\Models\Exam;
 use App\Models\ExamParticipant;
 use App\Models\ExamStepStatus;
+use App\Models\ExamPauseResult;
 use App\Models\TestAssignment;
 use App\Models\TestResult;
 use Inertia\Inertia;
@@ -239,6 +240,35 @@ class ParticipantController extends Controller
       'status' => 'broken',
       'completed_at' => now(),
     ]);
+
+    return back(303);
+  }
+
+  public function storePauseProgress(Request $request)
+  {
+    $user = Auth::user();
+
+    $data = $request->validate([
+      'exam_id' => 'required|exists:exams,id',
+      'exam_step_id' => 'required|exists:exam_steps,id',
+      'payload' => 'nullable|array',
+    ]);
+
+    $status = ExamStepStatus::where('exam_id', $data['exam_id'])
+      ->where('exam_step_id', $data['exam_step_id'])
+      ->where('participant_id', $user->id)
+      ->firstOrFail();
+
+    ExamPauseResult::updateOrCreate(
+      [
+        'exam_id' => $status->exam_id,
+        'exam_step_id' => $status->exam_step_id,
+        'participant_id' => $user->id,
+      ],
+      [
+        'payload' => $data['payload'] ?? [],
+      ],
+    );
 
     return back(303);
   }

--- a/app/Models/ExamPauseResult.php
+++ b/app/Models/ExamPauseResult.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ExamPauseResult extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'exam_id',
+        'exam_step_id',
+        'participant_id',
+        'payload',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+    ];
+}

--- a/database/migrations/2025_08_01_081800_create_exam_pause_results_table.php
+++ b/database/migrations/2025_08_01_081800_create_exam_pause_results_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('exam_pause_results', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('exam_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('exam_step_id')->constrained('exam_steps')->cascadeOnDelete();
+            $table->foreignId('participant_id')->constrained('users')->cascadeOnDelete();
+            $table->json('payload')->nullable();
+            $table->timestamps();
+
+            $table->unique(['exam_id', 'exam_step_id', 'participant_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('exam_pause_results');
+    }
+};

--- a/resources/js/pages/BRT-A.vue
+++ b/resources/js/pages/BRT-A.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3';
+import { Head } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -203,6 +203,32 @@ const startTest = () => {
   questionStartTimestamps.value = Array(questions.value.length).fill(null);
   startTime.value = null;
 };
+
+const getProgress = () => {
+  const now = Date.now();
+  const timesSnapshot = questionTimes.value.map((stored, index) => {
+    const startedAt = questionStartTimestamps.value[index];
+    if (startedAt) {
+      return stored + Math.round((now - startedAt) / 1000);
+    }
+    return stored;
+  });
+
+  return {
+    answers: [...userAnswers.value],
+    questionTimes: timesSnapshot,
+    currentQuestionIndex: currentQuestionIndex.value,
+    isTestComplete: isTestComplete.value,
+    showTest: showTest.value,
+    nextButtonClickCount: nextButtonClickCount.value,
+    startedAt: startTime.value,
+    elapsedSeconds: startTime.value ? Math.round((now - startTime.value) / 1000) : null,
+    totalQuestions: questions.value.length,
+    capturedAt: now,
+  };
+};
+
+defineExpose({ getProgress });
 
 </script>
 

--- a/resources/js/pages/BRT-B.vue
+++ b/resources/js/pages/BRT-B.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3';
+import { Head } from '@inertiajs/vue3';
 import { ref, computed, watch, nextTick } from 'vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -202,6 +202,32 @@ const startTest = () => {
   questionStartTimestamps.value = Array(questions.value.length).fill(null);
   startTime.value = null;
 };
+
+const getProgress = () => {
+  const now = Date.now();
+  const timesSnapshot = questionTimes.value.map((stored, index) => {
+    const startedAt = questionStartTimestamps.value[index];
+    if (startedAt) {
+      return stored + Math.round((now - startedAt) / 1000);
+    }
+    return stored;
+  });
+
+  return {
+    answers: [...userAnswers.value],
+    questionTimes: timesSnapshot,
+    currentQuestionIndex: currentQuestionIndex.value,
+    isTestComplete: isTestComplete.value,
+    showTest: showTest.value,
+    nextButtonClickCount: nextButtonClickCount.value,
+    startedAt: startTime.value,
+    elapsedSeconds: startTime.value ? Math.round((now - startTime.value) / 1000) : null,
+    totalQuestions: questions.value.length,
+    capturedAt: now,
+  };
+};
+
+defineExpose({ getProgress });
 
 </script>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::post('/my-exam/start-step', [ParticipantController::class, 'startStep'])->name('my-exam.start-step');
     Route::post('/my-exam/complete-step', [ParticipantController::class, 'completeStep'])->name('my-exam.complete-step');
     Route::post('/my-exam/break-step', [ParticipantController::class, 'breakStep'])->name('my-exam.break-step');
+    Route::post('/my-exam/pause-progress', [ParticipantController::class, 'storePauseProgress'])->name('my-exam.pause-progress');
 
     // Exam management (teacher/admin only, add middleware if needed)
     Route::post('/exam-step-status/{status}/add-time', [ExamStepStatusController::class, 'addTime'])->name('exam-step-status.add-time');


### PR DESCRIPTION
## Summary
- add an `ExamPauseResult` model, migration, and participant endpoint to store serialized pause snapshots
- have the teacher pause flow wait for a stored snapshot before finishing the response
- make the exam room request progress from active tests on remote pauses and expose progress getters for the BRT variants

## Testing
- npx eslint resources/js/pages/Exams/ExamRoom.vue resources/js/pages/BRT-A.vue resources/js/pages/BRT-B.vue

------
https://chatgpt.com/codex/tasks/task_e_68caadf598c4832985b7dd8ed7560fe9