### PR TITLE
Add participant-controlled pause workflow

### DIFF
--- a/app/Models/ExamStepStatus.php
+++ b/app/Models/ExamStepStatus.php
@@ -15,8 +15,15 @@ class ExamStepStatus extends Model
     'duration',
     'extra_time',
     'time_remaining_seconds',
+    'pause_button_enabled',
+    'paused_results',
     'started_at',
     'completed_at'
+  ];
+
+  protected $casts = [
+    'pause_button_enabled' => 'boolean',
+    'paused_results' => 'array',
   ];
 
   public function exam()

--- a/database/migrations/2025_08_01_081750_add_pause_button_columns_to_exam_step_statuses_table.php
+++ b/database/migrations/2025_08_01_081750_add_pause_button_columns_to_exam_step_statuses_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('exam_step_statuses', function (Blueprint $table) {
+            $table->boolean('pause_button_enabled')->default(false)->after('time_remaining_seconds');
+            $table->json('paused_results')->nullable()->after('pause_button_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('exam_step_statuses', function (Blueprint $table) {
+            $table->dropColumn(['paused_results', 'pause_button_enabled']);
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::middleware(['auth', 'verified', 'role.redirect'])->group(function () {
     Route::get('/no-exam', [ParticipantController::class, 'noExam'])->name('participant.no-exam');
     Route::post('/my-exam/start-step', [ParticipantController::class, 'startStep'])->name('my-exam.start-step');
     Route::post('/my-exam/complete-step', [ParticipantController::class, 'completeStep'])->name('my-exam.complete-step');
+    Route::post('/my-exam/pause-step', [ParticipantController::class, 'pauseStep'])->name('my-exam.pause-step');
     Route::post('/my-exam/break-step', [ParticipantController::class, 'breakStep'])->name('my-exam.break-step');
 
     // Exam management (teacher/admin only, add middleware if needed)


### PR DESCRIPTION
## Summary
- add pause button enablement fields to exam step statuses and expose them to Eloquent
- let participants request pauses via a new route that stores remaining time and results, while resetting pause state on start
- extend teacher controls and exam room UI so teachers can activate/deactivate pauses and participants see a pause button in the test dialog

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3e21764c8329ad618647f7932e10