### PR TITLE
Ensure PDF uses edited AVEM results

### DIFF
--- a/resources/js/components/PdfTemplate.vue
+++ b/resources/js/components/PdfTemplate.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import TestResultViewer from '@/components/TestResultViewer.vue';
 
-defineProps<{
+const props = defineProps<{
   assignment: any;
   participant: any;
   teacherName: string;
+  resultData?: any;
 }>();
 
 const testDate = new Date().toLocaleDateString('de-DE', {
@@ -51,7 +52,7 @@ const testDate = new Date().toLocaleDateString('de-DE', {
         <TestResultViewer
           v-if="assignment && assignment.results.length > 0"
           :test="assignment.test"
-          :model-value="assignment.results[0].result_json"
+          :model-value="props.resultData ?? assignment.results[0].result_json"
           :participant-profile="participant?.participant_profile"
         />
         <div v-else class="text-center text-gray-500">

--- a/resources/js/components/TestResultModal.vue
+++ b/resources/js/components/TestResultModal.vue
@@ -107,6 +107,7 @@ async function downloadUnifiedPdf() {
         :assignment="assignment"
         :participant="participant"
         :teacherName="teacherName"
+        :result-data="editable"
       />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- forward the edited result JSON into the hidden PDF template so the download reflects on-screen adjustments
- update the PDF view to consume the injected result data before falling back to the stored record

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5482b1ee083298d5aedfc9bee7706