### PR TITLE
Fix AVEM chart overlay appearing in MRT result charts

### DIFF
--- a/resources/js/components/AvemResult.vue
+++ b/resources/js/components/AvemResult.vue
@@ -250,7 +250,7 @@ const frameBorder = {
   },
 }
 
-Chart.register(topBottomPlugin, intervalsAndPointLabels, frameBorder)
+const localPlugins = [topBottomPlugin, intervalsAndPointLabels, frameBorder]
 
 /* ---------- options ---------- */
 const chartOptions = computed(() => ({
@@ -310,7 +310,7 @@ const detailRows = computed(() => {
   <div class="p-6 bg-background rounded-lg">
     <div class="mb-6 rounded-md bg-white p-4">
       <div style="width: 920px; height: 560px">
-        <Line :data="chartData" :options="chartOptions" />
+        <Line :data="chartData" :options="chartOptions" :plugins="localPlugins" />
       </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- AVEM-specific Chart.js drawing plugins (background band, frame, header/label drawing) were registered globally and continued to affect later charts (e.g. MRT-A / MRT-B) causing visual overlays.

### Description
- Stop global registration of AVEM-only Chart.js plugins and collect them into a local array `localPlugins` in `resources/js/components/AvemResult.vue`.
- Pass the AVEM-only plugins to the AVEM chart instance via the `:plugins` prop on the `<Line>` component so the custom drawing runs only for the AVEM chart (`<Line :data="chartData" :options="chartOptions" :plugins="localPlugins" />`).
- This prevents AVEM custom draw logic from leaking into other result charts opened afterwards.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6531d4c5083298809bd02a6061356)