### PR TITLE
Add BT question 1 manual scoring UI

### DIFF
--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { Input } from '@/components/ui/input';
+import axios from 'axios';
+import { computed, ref, watch } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    testResultId?: number | null;
+    manualScores?: Record<string, number | string | null>;
+  }>(),
+  {
+    manualScores: () => ({}),
+  },
+);
+
+const emit = defineEmits<{
+  'manual-score-updated': [{ key: string; value: number | null }];
+}>();
+
+const scoreKeys = {
+  earlyTwoSyllableCount: 'bt_q1_early_two_syllable_count',
+  earlyThreeSyllableCount: 'bt_q1_early_three_syllable_count',
+  lateOneSyllableCount: 'bt_q1_late_one_syllable_count',
+  lateThreeSyllableCount: 'bt_q1_late_three_syllable_count',
+} as const;
+
+const values = ref<Record<string, string>>({
+  [scoreKeys.earlyTwoSyllableCount]: '',
+  [scoreKeys.earlyThreeSyllableCount]: '',
+  [scoreKeys.lateOneSyllableCount]: '',
+  [scoreKeys.lateThreeSyllableCount]: '',
+});
+
+watch(
+  () => props.manualScores,
+  (next) => {
+    values.value[scoreKeys.earlyTwoSyllableCount] = toInput(next?.[scoreKeys.earlyTwoSyllableCount]);
+    values.value[scoreKeys.earlyThreeSyllableCount] = toInput(next?.[scoreKeys.earlyThreeSyllableCount]);
+    values.value[scoreKeys.lateOneSyllableCount] = toInput(next?.[scoreKeys.lateOneSyllableCount]);
+    values.value[scoreKeys.lateThreeSyllableCount] = toInput(next?.[scoreKeys.lateThreeSyllableCount]);
+  },
+  { immediate: true, deep: true },
+);
+
+const earlyTwoSyllablePoints = computed(() => (toNumber(values.value[scoreKeys.earlyTwoSyllableCount]) === 9 ? 3 : 0));
+const earlyThreeSyllablePoints = computed(() => (toNumber(values.value[scoreKeys.earlyThreeSyllableCount]) === 1 ? 1 : 0));
+const lateOneSyllablePoints = computed(() => (toNumber(values.value[scoreKeys.lateOneSyllableCount]) === 8 ? 3 : 0));
+const lateThreeSyllablePoints = computed(() => (toNumber(values.value[scoreKeys.lateThreeSyllableCount]) === 7 ? 2 : 0));
+
+const questionOneTotal = computed(
+  () =>
+    earlyTwoSyllablePoints.value +
+    earlyThreeSyllablePoints.value +
+    lateOneSyllablePoints.value +
+    lateThreeSyllablePoints.value,
+);
+
+function toInput(value: number | string | null | undefined) {
+  if (value == null || value === '') return '';
+  return `${value}`;
+}
+
+function toNumber(value: string): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function sanitizeAndSet(key: string, event: Event) {
+  const target = event.target as HTMLInputElement;
+  const sanitized = target.value.replace(/\D/g, '').slice(0, 2);
+  values.value[key] = sanitized;
+  target.value = sanitized;
+}
+
+async function persistValue(key: string) {
+  const numericValue = toNumber(values.value[key]);
+  emit('manual-score-updated', { key, value: numericValue });
+
+  if (!props.testResultId) return;
+
+  await axios.put(route('test-results.manual-scores.update', { testResult: props.testResultId }), {
+    key,
+    value: numericValue,
+  });
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <h3 class="text-lg font-semibold">BT – Aufgabe 1 (Scoring)</h3>
+    <p class="text-sm text-muted-foreground">
+      Punktvergabe: Frühdienst (9 zweisilbige Namen = 3 P.; 1 dreisilbiger Name = 1 P.),
+      Spätdienst (8 einsilbige Namen = 3 P.; 7 dreisilbige Namen = 2 P.)
+    </p>
+
+    <div class="overflow-x-auto">
+      <table class="min-w-full rounded-lg border text-sm shadow">
+        <thead class="bg-muted/40">
+          <tr>
+            <th class="px-3 py-2 text-left">Kriterium</th>
+            <th class="px-3 py-2 text-left">Eingabe</th>
+            <th class="px-3 py-2 text-left">Punkte</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="px-3 py-2">Frühdienst: zweisilbige Namen (Soll: 9)</td>
+            <td class="px-3 py-2">
+              <Input
+                :model-value="values[scoreKeys.earlyTwoSyllableCount]"
+                class="w-20"
+                inputmode="numeric"
+                @input="(event) => sanitizeAndSet(scoreKeys.earlyTwoSyllableCount, event)"
+                @blur="persistValue(scoreKeys.earlyTwoSyllableCount)"
+              />
+            </td>
+            <td class="px-3 py-2 font-semibold">{{ earlyTwoSyllablePoints }} / 3</td>
+          </tr>
+          <tr>
+            <td class="px-3 py-2">Frühdienst: dreisilbige Namen (Soll: 1)</td>
+            <td class="px-3 py-2">
+              <Input
+                :model-value="values[scoreKeys.earlyThreeSyllableCount]"
+                class="w-20"
+                inputmode="numeric"
+                @input="(event) => sanitizeAndSet(scoreKeys.earlyThreeSyllableCount, event)"
+                @blur="persistValue(scoreKeys.earlyThreeSyllableCount)"
+              />
+            </td>
+            <td class="px-3 py-2 font-semibold">{{ earlyThreeSyllablePoints }} / 1</td>
+          </tr>
+          <tr>
+            <td class="px-3 py-2">Spätdienst: einsilbige Namen (Soll: 8)</td>
+            <td class="px-3 py-2">
+              <Input
+                :model-value="values[scoreKeys.lateOneSyllableCount]"
+                class="w-20"
+                inputmode="numeric"
+                @input="(event) => sanitizeAndSet(scoreKeys.lateOneSyllableCount, event)"
+                @blur="persistValue(scoreKeys.lateOneSyllableCount)"
+              />
+            </td>
+            <td class="px-3 py-2 font-semibold">{{ lateOneSyllablePoints }} / 3</td>
+          </tr>
+          <tr>
+            <td class="px-3 py-2">Spätdienst: dreisilbige Namen (Soll: 7)</td>
+            <td class="px-3 py-2">
+              <Input
+                :model-value="values[scoreKeys.lateThreeSyllableCount]"
+                class="w-20"
+                inputmode="numeric"
+                @input="(event) => sanitizeAndSet(scoreKeys.lateThreeSyllableCount, event)"
+                @blur="persistValue(scoreKeys.lateThreeSyllableCount)"
+              />
+            </td>
+            <td class="px-3 py-2 font-semibold">{{ lateThreeSyllablePoints }} / 2</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr class="bg-muted/30">
+            <td class="px-3 py-2 font-semibold" colspan="2">Aufgabe 1 Gesamt</td>
+            <td class="px-3 py-2 font-bold">{{ questionOneTotal }} / 9</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+</template>

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -20,6 +20,7 @@ import { norms_male_60up } from '@/pages/Scores/FPI/norms_male_60up';
 import { computed, ref, watch } from 'vue';
 import BIT2Result from '@/components/BIT2Result.vue';
 import LpsResult from '@/components/LpsResult.vue';
+import BtResult from '@/components/BtResult.vue';
 
 interface Answer {
   question: string;
@@ -207,6 +208,12 @@ const fpiRohwerte = computed(() => {
           :results="local"
           :test-name="test.name"
           :participant-profile="participantProfile"
+          :test-result-id="testResultId"
+          :manual-scores="manualScoreMap"
+          @manual-score-updated="handleManualScoreUpdated"
+        />
+        <BtResult
+          v-else-if="test.name === 'BT'"
           :test-result-id="testResultId"
           :manual-scores="manualScoreMap"
           @manual-score-updated="handleManualScoreUpdated"

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -341,28 +341,46 @@ const debugScores = computed(() => {
     </div>
     <div
       v-if="showTest"
-      class="absolute bottom-4 right-4 z-20 w-[360px] rounded-lg border border-black bg-white/95 p-3 font-sans text-xs shadow-lg"
+      class="absolute bottom-4 right-4 z-20 w-[900px] max-w-[calc(100%-2rem)] rounded-lg border border-black bg-white/95 p-3 font-sans text-xs shadow-lg"
     >
-      <div class="mb-2 font-semibold">DEV: Dynamische Punkte (temporär)</div>
-      <div class="space-y-1">
-        <div>Aufgabe 1: <span class="font-bold">{{ debugScores.q1.points }}/9</span></div>
-        <div class="pl-2 text-[11px] text-muted-foreground">
-          F-2silb: {{ debugScores.q1.earlyTwoSyllable }}/9, F-3silb: {{ debugScores.q1.earlyThreeSyllable }}/1,
-          S-1silb: {{ debugScores.q1.lateOneSyllable }}/8, S-3silb: {{ debugScores.q1.lateThreeSyllable }}/7
+      <div class="mb-2 font-semibold">DEV: Dynamische Punkte (temporär, horizontal)</div>
+      <div class="grid grid-cols-6 gap-2">
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A1</div>
+          <div class="font-bold">{{ debugScores.q1.points }}/9</div>
+          <div class="text-[10px] text-muted-foreground">
+            F2 {{ debugScores.q1.earlyTwoSyllable }}/9 · F3 {{ debugScores.q1.earlyThreeSyllable }}/1
+          </div>
+          <div class="text-[10px] text-muted-foreground">
+            S1 {{ debugScores.q1.lateOneSyllable }}/8 · S3 {{ debugScores.q1.lateThreeSyllable }}/7
+          </div>
         </div>
-        <div>Aufgabe 2: <span class="font-bold">—</span> <span class="text-muted-foreground">{{ debugScores.q2.note }}</span></div>
-        <div>Aufgabe 3: <span class="font-bold">{{ debugScores.q3.points }}/{{ debugScores.q3.max }}</span> (richtige Felder)</div>
-        <div>
-          Aufgabe 4: <span class="font-bold">{{ debugScores.q4.points }}/{{ debugScores.q4.max }}</span>
-          <span class="text-muted-foreground">{{ debugScores.q4.note }}</span>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A2</div>
+          <div class="font-bold">—</div>
+          <div class="text-[10px] text-muted-foreground">{{ debugScores.q2.note }}</div>
         </div>
-        <div>
-          Aufgabe 5: <span class="font-bold">{{ debugScores.q5.points }}/{{ debugScores.q5.max }}</span>
-          <span class="text-muted-foreground">(korrekt: {{ debugScores.q5.correctDays }}, falsch: {{ debugScores.q5.wrongDays }})</span>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A3</div>
+          <div class="font-bold">{{ debugScores.q3.points }}/{{ debugScores.q3.max }}</div>
+          <div class="text-[10px] text-muted-foreground">richtige Felder</div>
         </div>
-        <div>
-          Aufgabe 6: <span class="font-bold">{{ debugScores.q6.points }}/{{ debugScores.q6.max }}</span>
-          <span class="text-muted-foreground">{{ debugScores.q6.note }}</span>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A4</div>
+          <div class="font-bold">{{ debugScores.q4.points }}/{{ debugScores.q4.max }}</div>
+          <div class="text-[10px] text-muted-foreground">Eingabe-Check</div>
+        </div>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A5</div>
+          <div class="font-bold">{{ debugScores.q5.points }}/{{ debugScores.q5.max }}</div>
+          <div class="text-[10px] text-muted-foreground">
+            ✓ {{ debugScores.q5.correctDays }} · ✗ {{ debugScores.q5.wrongDays }}
+          </div>
+        </div>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A6</div>
+          <div class="font-bold">{{ debugScores.q6.points }}/{{ debugScores.q6.max }}</div>
+          <div class="text-[10px] text-muted-foreground">Eingabe-Check</div>
         </div>
       </div>
     </div>

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -115,6 +115,39 @@ const routeTimes = ref<Record<string, string>>(
   ),
 );
 const routeTotals = ref({ totalWay: '', totalMsg: '', returnWay: '' });
+const q3ExpectedCashCounts: Record<string, number> = {
+  '100': 64,
+  '50': 3,
+  '20': 6,
+  '10': 3,
+  '5': 3,
+  '2': 4,
+  '1': 5,
+  '0.5': 4,
+};
+const q5ExpectedBuyDays = new Set([5, 7, 10]);
+const oneSyllableNames = new Set(['Fuchs', 'Hans', 'Kurz', 'Mann', 'Pahl', 'Paul', 'Pees', 'Roth']);
+const twoSyllableNames = new Set([
+  'Basten',
+  'Bauer',
+  'Bertram',
+  'Bolte',
+  'Krämer',
+  'Kühne',
+  'Müller',
+  'Schneider',
+  'Schuster',
+]);
+const threeSyllableNames = new Set([
+  'Angermann',
+  'Berkelhahn',
+  'Diesterweg',
+  'Eschweiler',
+  'Hamburger',
+  'Hamelring',
+  'Kleininger',
+  'Petersen',
+]);
 
 function buildCellKey(shift: 'early' | 'late', slot: number, day: string) {
   return `${shift}-${slot}-${day}`;
@@ -238,6 +271,65 @@ function startTest() {
   showTest.value = true;
   page.value = 1;
 }
+
+const debugScores = computed(() => {
+  const earlyAssigned = Object.entries(assignments.value)
+    .filter(([key, value]) => key.startsWith('early-') && value)
+    .map(([, value]) => value as string);
+  const lateAssigned = Object.entries(assignments.value)
+    .filter(([key, value]) => key.startsWith('late-') && value)
+    .map(([, value]) => value as string);
+
+  const earlyTwoSyllable = earlyAssigned.filter((name) => twoSyllableNames.has(name)).length;
+  const earlyThreeSyllable = earlyAssigned.filter((name) => threeSyllableNames.has(name)).length;
+  const lateOneSyllable = lateAssigned.filter((name) => oneSyllableNames.has(name)).length;
+  const lateThreeSyllable = lateAssigned.filter((name) => threeSyllableNames.has(name)).length;
+
+  const q1Points =
+    (earlyTwoSyllable === 9 ? 3 : 0) +
+    (earlyThreeSyllable === 1 ? 1 : 0) +
+    (lateOneSyllable === 8 ? 3 : 0) +
+    (lateThreeSyllable === 7 ? 2 : 0);
+
+  const q3CorrectFields = Object.entries(q3ExpectedCashCounts).reduce((sum, [key, expected]) => {
+    const actual = Number(cashAnswers.value[key] || 0);
+    return sum + (actual === expected ? 1 : 0);
+  }, 0);
+
+  const selectedDays = Object.entries(stampAnswerDays.value)
+    .filter(([, checked]) => checked)
+    .map(([day]) => Number(day));
+  const q5CorrectDays = selectedDays.filter((day) => q5ExpectedBuyDays.has(day)).length;
+  const q5WrongDays = selectedDays.filter((day) => !q5ExpectedBuyDays.has(day)).length;
+
+  return {
+    q1: {
+      points: q1Points,
+      earlyTwoSyllable,
+      earlyThreeSyllable,
+      lateOneSyllable,
+      lateThreeSyllable,
+    },
+    q2: { note: 'Keine Auto-Auswertung (Freitextaufgabe).' },
+    q3: { points: q3CorrectFields, max: 8 },
+    q4: {
+      points: Object.values(folderAnswers.value).filter((value) => value.trim().length > 0).length,
+      max: 10,
+      note: 'Nur Eingabe-Check (keine eindeutige Musterlösung hinterlegt).',
+    },
+    q5: {
+      points: Math.max(0, q5CorrectDays - q5WrongDays),
+      max: 3,
+      correctDays: q5CorrectDays,
+      wrongDays: q5WrongDays,
+    },
+    q6: {
+      points: routeRows.filter((row) => routeAssignments.value[`route-to-${row}`]).length,
+      max: 6,
+      note: 'Nur Eingabe-Check für Reihenfolge (kein Optimalitäts-Check).',
+    },
+  };
+});
 </script>
 
 <template>
@@ -246,6 +338,33 @@ function startTest() {
     <div v-if="showTest" class="absolute right-6 top-4 flex items-center gap-2">
       <Button variant="outline" @click="prevPage" :disabled="page === 1">Zurück</Button>
       <Button @click="nextPage" :disabled="page === maxPage">Weiter</Button>
+    </div>
+    <div
+      v-if="showTest"
+      class="absolute bottom-4 right-4 z-20 w-[360px] rounded-lg border border-black bg-white/95 p-3 font-sans text-xs shadow-lg"
+    >
+      <div class="mb-2 font-semibold">DEV: Dynamische Punkte (temporär)</div>
+      <div class="space-y-1">
+        <div>Aufgabe 1: <span class="font-bold">{{ debugScores.q1.points }}/9</span></div>
+        <div class="pl-2 text-[11px] text-muted-foreground">
+          F-2silb: {{ debugScores.q1.earlyTwoSyllable }}/9, F-3silb: {{ debugScores.q1.earlyThreeSyllable }}/1,
+          S-1silb: {{ debugScores.q1.lateOneSyllable }}/8, S-3silb: {{ debugScores.q1.lateThreeSyllable }}/7
+        </div>
+        <div>Aufgabe 2: <span class="font-bold">—</span> <span class="text-muted-foreground">{{ debugScores.q2.note }}</span></div>
+        <div>Aufgabe 3: <span class="font-bold">{{ debugScores.q3.points }}/{{ debugScores.q3.max }}</span> (richtige Felder)</div>
+        <div>
+          Aufgabe 4: <span class="font-bold">{{ debugScores.q4.points }}/{{ debugScores.q4.max }}</span>
+          <span class="text-muted-foreground">{{ debugScores.q4.note }}</span>
+        </div>
+        <div>
+          Aufgabe 5: <span class="font-bold">{{ debugScores.q5.points }}/{{ debugScores.q5.max }}</span>
+          <span class="text-muted-foreground">(korrekt: {{ debugScores.q5.correctDays }}, falsch: {{ debugScores.q5.wrongDays }})</span>
+        </div>
+        <div>
+          Aufgabe 6: <span class="font-bold">{{ debugScores.q6.points }}/{{ debugScores.q6.max }}</span>
+          <span class="text-muted-foreground">{{ debugScores.q6.note }}</span>
+        </div>
+      </div>
     </div>
     <div v-if="!showTest" class="flex h-full items-center justify-center px-6">
       <div class="max-w-5xl space-y-6 rounded-2xl border border-black/20 bg-white p-8 font-serif text-base leading-relaxed shadow-sm">


### PR DESCRIPTION
### Motivation
- Implement a small manual-scoring UI for BT question 1 so graders can enter the four syllable-count criteria and get an immediate derived score according to the specified rules.
- Integrate the UI into the existing test-result editing flow so manual scores persist via the existing API and propagate to result updates.
- Skill used: none — changes were made directly to the codebase.

### Description
- Add a new component `resources/js/components/BtResult.vue` that exposes numeric inputs for the four criteria and sanitizes input, computes per-criterion points, and derives a live total `questionOneTotal` (out of 9).
- Use the manual-score keys `bt_q1_early_two_syllable_count`, `bt_q1_early_three_syllable_count`, `bt_q1_late_one_syllable_count`, and `bt_q1_late_three_syllable_count` and emit `manual-score-updated` when values change.
- Persist each criterion to the backend on blur via the existing `test-results.manual-scores.update` API (`axios.put(route('test-results.manual-scores.update', ...))`).
- Wire the component into `resources/js/components/TestResultViewer.vue` so it is rendered when `test.name === 'BT'` and receives `testResultId` and `manualScores`.

### Testing
- Ran `npx eslint resources/js/components/BtResult.vue resources/js/components/TestResultViewer.vue`, which completed without errors for the changed files.
- Ran `npm run lint -- resources/js/components/BtResult.vue resources/js/components/TestResultViewer.vue`, which reported repository-wide pre-existing lint issues outside the changed files (the new component files themselves are fine).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ce3c7732a88329b905931d20983551)