### PR TITLE
Add BT Aufgabe 4 manual scoring UI and logic

### DIFF
--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -80,8 +80,8 @@ watch(
     values.value[scoreKeys.q3Count1] = toInput(next?.[scoreKeys.q3Count1]);
     values.value[scoreKeys.q3Count050] = toInput(next?.[scoreKeys.q3Count050]);
     values.value[scoreKeys.q4CorrectFolderCount] = toInput(next?.[scoreKeys.q4CorrectFolderCount]);
-    q4AlphabeticalOrderMet.value = toNumber(toInput(next?.[scoreKeys.q4AlphabeticalOrderMet])) === 1;
-    q4FolderOrderMet.value = toNumber(toInput(next?.[scoreKeys.q4FolderOrderMet])) === 1;
+    q4AlphabeticalOrderMet.value = toBoolean(next?.[scoreKeys.q4AlphabeticalOrderMet]);
+    q4FolderOrderMet.value = toBoolean(next?.[scoreKeys.q4FolderOrderMet]);
   },
   { immediate: true, deep: true },
 );
@@ -106,18 +106,19 @@ const questionThreeTotal = computed(() =>
   }, 0),
 );
 const questionFourBasePoints = computed(() => {
-  const correctFolders = toNumber(values.value[scoreKeys.q4CorrectFolderCount]);
+  const correctFolders = toClampedFolderCount(values.value[scoreKeys.q4CorrectFolderCount]);
   if (correctFolders == null || correctFolders < 1) return 0;
   if (correctFolders <= 4) return 2;
   if (correctFolders <= 9) return 4;
-  if (correctFolders >= 10) return 6;
+  if (correctFolders === 10) return 6;
   return 0;
 });
+const questionFourAlphabeticalPoints = computed(() => (questionFourBasePoints.value === 6 && q4AlphabeticalOrderMet.value ? 1 : 0));
+const questionFourFolderOrderPoints = computed(() =>
+  questionFourBasePoints.value === 6 && q4AlphabeticalOrderMet.value && q4FolderOrderMet.value ? 1 : 0,
+);
 const questionFourTotal = computed(() => {
-  if (questionFourBasePoints.value < 6) return questionFourBasePoints.value;
-  if (!q4AlphabeticalOrderMet.value) return 6;
-  if (!q4FolderOrderMet.value) return 7;
-  return 8;
+  return questionFourBasePoints.value + questionFourAlphabeticalPoints.value + questionFourFolderOrderPoints.value;
 });
 
 function toInput(value: number | string | null | undefined) {
@@ -131,9 +132,26 @@ function toNumber(value: string): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+function toBoolean(value: unknown): boolean {
+  if (value === true || value === 1 || value === '1' || value === 'true') return true;
+  return false;
+}
+
+function toClampedFolderCount(value: string): number | null {
+  const parsed = toNumber(value);
+  if (parsed == null) return null;
+  return Math.max(0, Math.min(10, parsed));
+}
+
 function sanitizeAndSet(key: string, event: Event) {
   const target = event.target as HTMLInputElement;
   const sanitized = target.value.replace(/\D/g, '').slice(0, 2);
+  if (key === scoreKeys.q4CorrectFolderCount) {
+    const numeric = sanitized === '' ? '' : `${Math.min(10, Number(sanitized))}`;
+    values.value[key] = numeric;
+    target.value = numeric;
+    return;
+  }
   values.value[key] = sanitized;
   target.value = sanitized;
 }
@@ -319,7 +337,7 @@ async function persistBooleanValue(key: string, value: boolean) {
                 @change="persistBooleanValue(scoreKeys.q4AlphabeticalOrderMet, q4AlphabeticalOrderMet)"
               />
             </td>
-            <td class="px-3 py-2 font-semibold">{{ questionFourBasePoints < 6 ? 0 : q4AlphabeticalOrderMet ? 1 : 0 }} / 1</td>
+            <td class="px-3 py-2 font-semibold">{{ questionFourAlphabeticalPoints }} / 1</td>
           </tr>
           <tr>
             <td class="px-3 py-2">Ordner-Reihenfolge eingehalten</td>
@@ -331,7 +349,7 @@ async function persistBooleanValue(key: string, value: boolean) {
                 @change="persistBooleanValue(scoreKeys.q4FolderOrderMet, q4FolderOrderMet)"
               />
             </td>
-            <td class="px-3 py-2 font-semibold">{{ questionFourBasePoints < 6 || !q4AlphabeticalOrderMet ? 0 : q4FolderOrderMet ? 1 : 0 }} / 1</td>
+            <td class="px-3 py-2 font-semibold">{{ questionFourFolderOrderPoints }} / 1</td>
           </tr>
         </tbody>
         <tfoot>

--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -30,6 +30,9 @@ const scoreKeys = {
   q3Count2: 'bt_q3_count_2',
   q3Count1: 'bt_q3_count_1',
   q3Count050: 'bt_q3_count_050',
+  q4CorrectFolderCount: 'bt_q4_correct_folder_count',
+  q4AlphabeticalOrderMet: 'bt_q4_alphabetical_order_met',
+  q4FolderOrderMet: 'bt_q4_folder_order_met',
 } as const;
 
 const questionThreeCriteria = [
@@ -56,7 +59,10 @@ const values = ref<Record<string, string>>({
   [scoreKeys.q3Count2]: '',
   [scoreKeys.q3Count1]: '',
   [scoreKeys.q3Count050]: '',
+  [scoreKeys.q4CorrectFolderCount]: '',
 });
+const q4AlphabeticalOrderMet = ref(false);
+const q4FolderOrderMet = ref(false);
 
 watch(
   () => props.manualScores,
@@ -73,6 +79,9 @@ watch(
     values.value[scoreKeys.q3Count2] = toInput(next?.[scoreKeys.q3Count2]);
     values.value[scoreKeys.q3Count1] = toInput(next?.[scoreKeys.q3Count1]);
     values.value[scoreKeys.q3Count050] = toInput(next?.[scoreKeys.q3Count050]);
+    values.value[scoreKeys.q4CorrectFolderCount] = toInput(next?.[scoreKeys.q4CorrectFolderCount]);
+    q4AlphabeticalOrderMet.value = toNumber(toInput(next?.[scoreKeys.q4AlphabeticalOrderMet])) === 1;
+    q4FolderOrderMet.value = toNumber(toInput(next?.[scoreKeys.q4FolderOrderMet])) === 1;
   },
   { immediate: true, deep: true },
 );
@@ -96,6 +105,20 @@ const questionThreeTotal = computed(() =>
     return sum + (value === criterion.expected ? 1 : 0);
   }, 0),
 );
+const questionFourBasePoints = computed(() => {
+  const correctFolders = toNumber(values.value[scoreKeys.q4CorrectFolderCount]);
+  if (correctFolders == null || correctFolders < 1) return 0;
+  if (correctFolders <= 4) return 2;
+  if (correctFolders <= 9) return 4;
+  if (correctFolders >= 10) return 6;
+  return 0;
+});
+const questionFourTotal = computed(() => {
+  if (questionFourBasePoints.value < 6) return questionFourBasePoints.value;
+  if (!q4AlphabeticalOrderMet.value) return 6;
+  if (!q4FolderOrderMet.value) return 7;
+  return 8;
+});
 
 function toInput(value: number | string | null | undefined) {
   if (value == null || value === '') return '';
@@ -117,6 +140,18 @@ function sanitizeAndSet(key: string, event: Event) {
 
 async function persistValue(key: string) {
   const numericValue = toNumber(values.value[key]);
+  emit('manual-score-updated', { key, value: numericValue });
+
+  if (!props.testResultId) return;
+
+  await axios.put(route('test-results.manual-scores.update', { testResult: props.testResultId }), {
+    key,
+    value: numericValue,
+  });
+}
+
+async function persistBooleanValue(key: string, value: boolean) {
+  const numericValue = value ? 1 : 0;
   emit('manual-score-updated', { key, value: numericValue });
 
   if (!props.testResultId) return;
@@ -241,6 +276,68 @@ async function persistValue(key: string) {
           <tr class="bg-muted/30">
             <td class="px-3 py-2 font-semibold" colspan="3">Aufgabe 3 Gesamt</td>
             <td class="px-3 py-2 font-bold">{{ questionThreeTotal }} / 8</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+
+    <h3 class="text-lg font-semibold">BT – Aufgabe 4 (Scoring)</h3>
+    <p class="text-sm text-muted-foreground">
+      Punktvergabe: 1–4 richtige Ordner = 2 P., 5–9 = 4 P., 10 = 6 P.; bei 10 Ordnern zusätzlich
+      alphabetische Reihenfolge eingehalten = +1 P., Ordner-Reihenfolge eingehalten = +1 P.
+    </p>
+    <div class="overflow-x-auto">
+      <table class="min-w-full rounded-lg border text-sm shadow">
+        <thead class="bg-muted/40">
+          <tr>
+            <th class="px-3 py-2 text-left">Kriterium</th>
+            <th class="px-3 py-2 text-left">Eingabe</th>
+            <th class="px-3 py-2 text-left">Punkte</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="px-3 py-2">Richtig verteilte Ordner (0–10)</td>
+            <td class="px-3 py-2">
+              <Input
+                :model-value="values[scoreKeys.q4CorrectFolderCount]"
+                class="w-20"
+                inputmode="numeric"
+                @input="(event) => sanitizeAndSet(scoreKeys.q4CorrectFolderCount, event)"
+                @blur="persistValue(scoreKeys.q4CorrectFolderCount)"
+              />
+            </td>
+            <td class="px-3 py-2 font-semibold">{{ questionFourBasePoints }} / 6</td>
+          </tr>
+          <tr>
+            <td class="px-3 py-2">Alphabetische Reihenfolge eingehalten</td>
+            <td class="px-3 py-2">
+              <input
+                v-model="q4AlphabeticalOrderMet"
+                type="checkbox"
+                class="h-4 w-4 align-middle"
+                @change="persistBooleanValue(scoreKeys.q4AlphabeticalOrderMet, q4AlphabeticalOrderMet)"
+              />
+            </td>
+            <td class="px-3 py-2 font-semibold">{{ questionFourBasePoints < 6 ? 0 : q4AlphabeticalOrderMet ? 1 : 0 }} / 1</td>
+          </tr>
+          <tr>
+            <td class="px-3 py-2">Ordner-Reihenfolge eingehalten</td>
+            <td class="px-3 py-2">
+              <input
+                v-model="q4FolderOrderMet"
+                type="checkbox"
+                class="h-4 w-4 align-middle"
+                @change="persistBooleanValue(scoreKeys.q4FolderOrderMet, q4FolderOrderMet)"
+              />
+            </td>
+            <td class="px-3 py-2 font-semibold">{{ questionFourBasePoints < 6 || !q4AlphabeticalOrderMet ? 0 : q4FolderOrderMet ? 1 : 0 }} / 1</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr class="bg-muted/30">
+            <td class="px-3 py-2 font-semibold" colspan="2">Aufgabe 4 Gesamt</td>
+            <td class="px-3 py-2 font-bold">{{ questionFourTotal }} / 8</td>
           </tr>
         </tfoot>
       </table>

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -125,6 +125,11 @@ const q3ExpectedCashCounts: Record<string, number> = {
   '1': 5,
   '0.5': 4,
 };
+const btAlphabet = 'ABCDEFGHJKLMNOPQRSTUVWXYZ';
+const q4ExpectedFolders = {
+  A: ['ABCD', 'E', 'FGHJ', 'KL', 'M', 'NO', 'PQR', 'ST', 'UV', 'WXYZ'],
+  B: ['AB', 'CD', 'E', 'FGHJ', 'KLMN', 'OPQR', 'S', 'TU', 'VW', 'XYZ'],
+} as const;
 const q5ExpectedBuyDays = new Set([5, 7, 10]);
 const oneSyllableNames = new Set(['Fuchs', 'Hans', 'Kurz', 'Mann', 'Pahl', 'Paul', 'Pees', 'Roth']);
 const twoSyllableNames = new Set([
@@ -272,6 +277,49 @@ function startTest() {
   page.value = 1;
 }
 
+function normalizeFolderLetters(value: string) {
+  return value
+    .toUpperCase()
+    .replace(/[^A-Z]/g, '')
+    .split('')
+    .filter((char, index, arr) => btAlphabet.includes(char) && arr.indexOf(char) === index);
+}
+
+function isAlphabetical(chars: string[]) {
+  return chars.every((char, index) => index === 0 || btAlphabet.indexOf(chars[index - 1]) <= btAlphabet.indexOf(char));
+}
+
+function evaluateQ4ForForm(expectedFolders: readonly string[]) {
+  const answers = Array.from({ length: 10 }, (_, index) => normalizeFolderLetters(folderAnswers.value[index + 1]));
+  const normalizedExpected = expectedFolders.map((folder) => folder.split(''));
+
+  const unusedExpected = normalizedExpected.map((chars) => chars.join(''));
+  let correctFolderCount = 0;
+
+  answers.forEach((chars) => {
+    const normalized = [...chars].sort((a, b) => btAlphabet.indexOf(a) - btAlphabet.indexOf(b)).join('');
+    const matchIndex = unusedExpected.indexOf(normalized);
+    if (matchIndex >= 0) {
+      correctFolderCount += 1;
+      unusedExpected.splice(matchIndex, 1);
+    }
+  });
+
+  const alphabeticalOrderMet = answers.every((chars) => isAlphabetical(chars));
+  const folderOrderMet = answers.every((chars, index) => chars.join('') === normalizedExpected[index].join(''));
+
+  let points = 0;
+  if (correctFolderCount >= 1 && correctFolderCount <= 4) points = 2;
+  else if (correctFolderCount >= 5 && correctFolderCount <= 9) points = 4;
+  else if (correctFolderCount === 10) points = 6;
+
+  if (correctFolderCount === 10 && alphabeticalOrderMet) {
+    points = folderOrderMet ? 8 : 7;
+  }
+
+  return { points, correctFolderCount, alphabeticalOrderMet, folderOrderMet };
+}
+
 const debugScores = computed(() => {
   const earlyAssigned = Object.entries(assignments.value)
     .filter(([key, value]) => key.startsWith('early-') && value)
@@ -302,6 +350,10 @@ const debugScores = computed(() => {
   const q5CorrectDays = selectedDays.filter((day) => q5ExpectedBuyDays.has(day)).length;
   const q5WrongDays = selectedDays.filter((day) => !q5ExpectedBuyDays.has(day)).length;
 
+  const q4FormA = evaluateQ4ForForm(q4ExpectedFolders.A);
+  const q4FormB = evaluateQ4ForForm(q4ExpectedFolders.B);
+  const q4Best = q4FormA.points >= q4FormB.points ? { form: 'A', ...q4FormA } : { form: 'B', ...q4FormB };
+
   return {
     q1: {
       points: q1Points,
@@ -313,9 +365,12 @@ const debugScores = computed(() => {
     q2: { note: 'Keine Auto-Auswertung (Freitextaufgabe).' },
     q3: { points: q3CorrectFields, max: 8 },
     q4: {
-      points: Object.values(folderAnswers.value).filter((value) => value.trim().length > 0).length,
-      max: 10,
-      note: 'Nur Eingabe-Check (keine eindeutige Musterlösung hinterlegt).',
+      points: q4Best.points,
+      max: 8,
+      form: q4Best.form,
+      correctFolders: q4Best.correctFolderCount,
+      alphabeticalOrderMet: q4Best.alphabeticalOrderMet,
+      folderOrderMet: q4Best.folderOrderMet,
     },
     q5: {
       points: Math.max(0, q5CorrectDays - q5WrongDays),
@@ -368,7 +423,12 @@ const debugScores = computed(() => {
         <div class="rounded border border-black/20 px-2 py-1">
           <div class="font-semibold">A4</div>
           <div class="font-bold">{{ debugScores.q4.points }}/{{ debugScores.q4.max }}</div>
-          <div class="text-[10px] text-muted-foreground">Eingabe-Check</div>
+          <div class="text-[10px] text-muted-foreground">
+            Form {{ debugScores.q4.form }} · Ordner {{ debugScores.q4.correctFolders }}/10
+          </div>
+          <div class="text-[10px] text-muted-foreground">
+            Alpha {{ debugScores.q4.alphabeticalOrderMet ? '✓' : '✗' }} · Reihenfolge {{ debugScores.q4.folderOrderMet ? '✓' : '✗' }}
+          </div>
         </div>
         <div class="rounded border border-black/20 px-2 py-1">
           <div class="font-semibold">A5</div>

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -294,15 +294,11 @@ function isAlphabetical(chars: string[]) {
 
 function evaluateQ4() {
   const answers = Array.from({ length: 10 }, (_, index) => normalizeFolderLetters(folderAnswers.value[index + 1]));
-  const globalLetterCounts = answers
-    .flat()
-    .reduce<Record<string, number>>((counts, char) => {
-      counts[char] = (counts[char] ?? 0) + 1;
-      return counts;
-    }, {});
+  const seenLetters = new Set<string>();
   const folderWeights = answers.map((chars) =>
     chars.reduce((sum, char) => {
-      if (globalLetterCounts[char] !== 1) return sum;
+      if (seenLetters.has(char)) return sum;
+      seenLetters.add(char);
       return sum + (q4LetterWeights[char] ?? 0);
     }, 0),
   );

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -126,10 +126,13 @@ const q3ExpectedCashCounts: Record<string, number> = {
   '0.5': 4,
 };
 const btAlphabet = 'ABCDEFGHJKLMNOPQRSTUVWXYZ';
-const q4ExpectedFolders = {
-  A: ['ABCD', 'E', 'FGHJ', 'KL', 'M', 'NO', 'PQR', 'ST', 'UV', 'WXYZ'],
-  B: ['AB', 'CD', 'E', 'FGHJ', 'KLMN', 'OPQR', 'S', 'TU', 'VW', 'XYZ'],
-} as const;
+const q4LetterWeights: Record<string, number> = {
+  A: 15, F: 15, W: 15, B: 15, G: 15, J: 15, X: 15, Y: 15, C: 15, H: 15, Z: 15, D: 15, // 2.5%
+  R: 20, P: 20, Q: 20, // 3.33%
+  N: 30, K: 30, S: 30, V: 30, T: 30, U: 30, O: 30, L: 30, // 5%
+  M: 60, E: 60, // 10%
+};
+const q4TargetFolderWeight = 60; // 10%
 const q5ExpectedBuyDays = new Set([5, 7, 10]);
 const oneSyllableNames = new Set(['Fuchs', 'Hans', 'Kurz', 'Mann', 'Pahl', 'Paul', 'Pees', 'Roth']);
 const twoSyllableNames = new Set([
@@ -289,24 +292,19 @@ function isAlphabetical(chars: string[]) {
   return chars.every((char, index) => index === 0 || btAlphabet.indexOf(chars[index - 1]) <= btAlphabet.indexOf(char));
 }
 
-function evaluateQ4ForForm(expectedFolders: readonly string[]) {
+function evaluateQ4() {
   const answers = Array.from({ length: 10 }, (_, index) => normalizeFolderLetters(folderAnswers.value[index + 1]));
-  const normalizedExpected = expectedFolders.map((folder) => folder.split(''));
-
-  const unusedExpected = normalizedExpected.map((chars) => chars.join(''));
-  let correctFolderCount = 0;
-
-  answers.forEach((chars) => {
-    const normalized = [...chars].sort((a, b) => btAlphabet.indexOf(a) - btAlphabet.indexOf(b)).join('');
-    const matchIndex = unusedExpected.indexOf(normalized);
-    if (matchIndex >= 0) {
-      correctFolderCount += 1;
-      unusedExpected.splice(matchIndex, 1);
-    }
-  });
+  const folderWeights = answers.map((chars) => chars.reduce((sum, char) => sum + (q4LetterWeights[char] ?? 0), 0));
+  const correctFolderCount = folderWeights.filter((weight) => weight === q4TargetFolderWeight).length;
 
   const alphabeticalOrderMet = answers.every((chars) => isAlphabetical(chars));
-  const folderOrderMet = answers.every((chars, index) => chars.join('') === normalizedExpected[index].join(''));
+  const folderOrderMet = answers.every((chars, index) => {
+    if (index === answers.length - 1) return true;
+    const currentIndices = chars.map((char) => btAlphabet.indexOf(char));
+    const nextIndices = answers[index + 1].map((char) => btAlphabet.indexOf(char));
+    if (!currentIndices.length || !nextIndices.length) return false;
+    return Math.max(...currentIndices) < Math.min(...nextIndices);
+  });
 
   let points = 0;
   if (correctFolderCount >= 1 && correctFolderCount <= 4) points = 2;
@@ -317,7 +315,7 @@ function evaluateQ4ForForm(expectedFolders: readonly string[]) {
     points = folderOrderMet ? 8 : 7;
   }
 
-  return { points, correctFolderCount, alphabeticalOrderMet, folderOrderMet };
+  return { points, correctFolderCount, alphabeticalOrderMet, folderOrderMet, folderWeights };
 }
 
 const debugScores = computed(() => {
@@ -350,9 +348,7 @@ const debugScores = computed(() => {
   const q5CorrectDays = selectedDays.filter((day) => q5ExpectedBuyDays.has(day)).length;
   const q5WrongDays = selectedDays.filter((day) => !q5ExpectedBuyDays.has(day)).length;
 
-  const q4FormA = evaluateQ4ForForm(q4ExpectedFolders.A);
-  const q4FormB = evaluateQ4ForForm(q4ExpectedFolders.B);
-  const q4Best = q4FormA.points >= q4FormB.points ? { form: 'A', ...q4FormA } : { form: 'B', ...q4FormB };
+  const q4 = evaluateQ4();
 
   return {
     q1: {
@@ -365,12 +361,12 @@ const debugScores = computed(() => {
     q2: { note: 'Keine Auto-Auswertung (Freitextaufgabe).' },
     q3: { points: q3CorrectFields, max: 8 },
     q4: {
-      points: q4Best.points,
+      points: q4.points,
       max: 8,
-      form: q4Best.form,
-      correctFolders: q4Best.correctFolderCount,
-      alphabeticalOrderMet: q4Best.alphabeticalOrderMet,
-      folderOrderMet: q4Best.folderOrderMet,
+      correctFolders: q4.correctFolderCount,
+      alphabeticalOrderMet: q4.alphabeticalOrderMet,
+      folderOrderMet: q4.folderOrderMet,
+      folderWeights: q4.folderWeights,
     },
     q5: {
       points: Math.max(0, q5CorrectDays - q5WrongDays),
@@ -424,10 +420,13 @@ const debugScores = computed(() => {
           <div class="font-semibold">A4</div>
           <div class="font-bold">{{ debugScores.q4.points }}/{{ debugScores.q4.max }}</div>
           <div class="text-[10px] text-muted-foreground">
-            Form {{ debugScores.q4.form }} · Ordner {{ debugScores.q4.correctFolders }}/10
+            Ordner mit 10%: {{ debugScores.q4.correctFolders }}/10
           </div>
           <div class="text-[10px] text-muted-foreground">
             Alpha {{ debugScores.q4.alphabeticalOrderMet ? '✓' : '✗' }} · Reihenfolge {{ debugScores.q4.folderOrderMet ? '✓' : '✗' }}
+          </div>
+          <div class="text-[10px] text-muted-foreground">
+            Gewichte: {{ debugScores.q4.folderWeights.join(' / ') }}
           </div>
         </div>
         <div class="rounded border border-black/20 px-2 py-1">

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -294,7 +294,18 @@ function isAlphabetical(chars: string[]) {
 
 function evaluateQ4() {
   const answers = Array.from({ length: 10 }, (_, index) => normalizeFolderLetters(folderAnswers.value[index + 1]));
-  const folderWeights = answers.map((chars) => chars.reduce((sum, char) => sum + (q4LetterWeights[char] ?? 0), 0));
+  const globalLetterCounts = answers
+    .flat()
+    .reduce<Record<string, number>>((counts, char) => {
+      counts[char] = (counts[char] ?? 0) + 1;
+      return counts;
+    }, {});
+  const folderWeights = answers.map((chars) =>
+    chars.reduce((sum, char) => {
+      if (globalLetterCounts[char] !== 1) return sum;
+      return sum + (q4LetterWeights[char] ?? 0);
+    }, 0),
+  );
   const correctFolderCount = folderWeights.filter((weight) => weight === q4TargetFolderWeight).length;
 
   const alphabeticalOrderMet = answers.every((chars) => isAlphabetical(chars));


### PR DESCRIPTION
### Motivation
- Provide manual scoring support for BT question 4 so examiners can enter folder counts and two boolean criteria and get live point totals according to the rubric.

### Description
- Added new manual score keys `bt_q4_correct_folder_count`, `bt_q4_alphabetical_order_met`, and `bt_q4_folder_order_met` and wired them into `resources/js/components/BtResult.vue`.
- Introduced state refs `q4AlphabeticalOrderMet` and `q4FolderOrderMet`, plus a string-backed `values` entry for the correct-folder count, and added parsing helpers using `toInput`/`toNumber`.
- Implemented computed scoring logic with `questionFourBasePoints` and `questionFourTotal` to match the rubric (1–4 => 2 pts, 5–9 => 4 pts, 10 => 6 pts, +1 for alphabetical when 10, +1 for folder order when alphabetical met).
- Added `persistBooleanValue` to persist boolean criteria as `1/0` to the existing `test-results.manual-scores.update` endpoint and added a UI table with input and checkboxes showing per-criterion and total points.

### Testing
- Ran `npx eslint resources/js/components/BtResult.vue` and the lint check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfb74c244832985dede52a6bfe594)