### PR TITLE
Add manual scoring support for BT Aufgabe 6

### DIFF
--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -43,6 +43,7 @@ const scoreKeys = {
     q5Day8Selected: 'bt_q5_day_8_selected',
     q5Day9Selected: 'bt_q5_day_9_selected',
     q5Day10Selected: 'bt_q5_day_10_selected',
+    q6Score: 'bt_q6_score',
 } as const;
 const q5CorrectDays = new Set([5, 7, 10]);
 const q5DayPoints: Record<number, number> = {
@@ -61,6 +62,38 @@ const q5DayEntries = [
     { day: 8, key: scoreKeys.q5Day8Selected },
     { day: 9, key: scoreKeys.q5Day9Selected },
     { day: 10, key: scoreKeys.q5Day10Selected },
+] as const;
+const q6OptionEntries = [
+    {
+        key: 'attempt_without_phone',
+        label: 'Nur Ansatz ohne Telefon',
+        description: 'Ansatz erkennbar (Name/Namenskürzel/Zahlenspuren oder Radierungen), aber kein Telefon genutzt.',
+        points: 2,
+    },
+    {
+        key: 'attempt_with_phone',
+        label: 'Ansatz mit Telefon',
+        description: 'Ansatz vorhanden und Telefon bereits genutzt.',
+        points: 4,
+    },
+    {
+        key: 'completed_cumbersome_without_phone',
+        label: 'Auftrag erledigt, umständlich ohne Telefon',
+        description: 'Auftrag vollständig erledigt, aber umständlich und ohne Telefonnutzung.',
+        points: 6,
+    },
+    {
+        key: 'completed_cumbersome_with_phone',
+        label: 'Auftrag erledigt, umständlich mit Telefon',
+        description: 'Auftrag vollständig erledigt, aber umständlich und mit Telefonnutzung.',
+        points: 7,
+    },
+    {
+        key: 'best_time',
+        label: 'Bestzeit / Musterlösung',
+        description: 'Benachrichtigung in Bestzeit (ohne Zeit für Rückweg zur Wohnung).',
+        points: 8,
+    },
 ] as const;
 
 const questionThreeCriteria = [
@@ -88,10 +121,12 @@ const values = ref<Record<string, string>>({
     [scoreKeys.q3Count1]: '',
     [scoreKeys.q3Count050]: '',
     [scoreKeys.q4CorrectFolderCount]: '',
+    [scoreKeys.q6Score]: '',
 });
 const q4AlphabeticalOrderMet = ref(false);
 const q4FolderOrderMet = ref(false);
 const q5SelectedDays = ref<Record<number, boolean>>(Object.fromEntries(q5DayEntries.map((entry) => [entry.day, false])));
+const q6SelectedOption = ref<(typeof q6OptionEntries)[number]['key'] | null>(null);
 
 watch(
     () => props.manualScores,
@@ -114,6 +149,9 @@ watch(
         q5DayEntries.forEach((entry) => {
             q5SelectedDays.value[entry.day] = toBoolean(next?.[entry.key]);
         });
+        values.value[scoreKeys.q6Score] = toInput(next?.[scoreKeys.q6Score]);
+        const persistedQ6Points = toNumber(values.value[scoreKeys.q6Score]);
+        q6SelectedOption.value = q6OptionEntries.find((entry) => entry.points === persistedQ6Points)?.key ?? null;
     },
     { immediate: true, deep: true },
 );
@@ -154,6 +192,7 @@ const questionFiveTotal = computed(() =>
         return total + (q5DayPoints[entry.day] ?? 0);
     }, 0),
 );
+const questionSixTotal = computed(() => q6OptionEntries.find((entry) => entry.key === q6SelectedOption.value)?.points ?? 0);
 
 function toInput(value: number | string | null | undefined) {
     if (value == null || value === '') return '';
@@ -222,6 +261,16 @@ async function persistQ5DayValue(day: number) {
     const key = q5StorageKeyForDay(day);
     if (!key) return;
     await persistBooleanValue(key, q5SelectedDays.value[day] === true);
+}
+
+async function persistQ6Value() {
+    await persistValue(scoreKeys.q6Score);
+}
+
+async function setQ6Option(key: (typeof q6OptionEntries)[number]['key']) {
+    q6SelectedOption.value = key;
+    values.value[scoreKeys.q6Score] = `${q6OptionEntries.find((entry) => entry.key === key)?.points ?? 0}`;
+    await persistQ6Value();
 }
 </script>
 
@@ -406,9 +455,7 @@ async function persistQ5DayValue(day: number) {
         </div>
 
         <h3 class="text-lg font-semibold">BT – Aufgabe 5 (Scoring)</h3>
-        <p class="text-sm text-muted-foreground">
-            Punktvergabe Form A: 5. Tag = 2 P., 7. Tag = 2 P., 10. Tag = 4 P.
-        </p>
+        <p class="text-sm text-muted-foreground">Punktvergabe Form A: 5. Tag = 2 P., 7. Tag = 2 P., 10. Tag = 4 P.</p>
         <div class="overflow-x-auto">
             <table class="min-w-full rounded-lg border text-sm shadow">
                 <thead class="bg-muted/40">
@@ -430,7 +477,7 @@ async function persistQ5DayValue(day: number) {
                             />
                         </td>
                         <td class="px-3 py-2 font-semibold">
-                            {{ q5SelectedDays[entry.day] && q5CorrectDays.has(entry.day) ? q5DayPoints[entry.day] ?? 0 : 0 }}
+                            {{ q5SelectedDays[entry.day] && q5CorrectDays.has(entry.day) ? (q5DayPoints[entry.day] ?? 0) : 0 }}
                             / {{ q5DayPoints[entry.day] ?? 0 }}
                         </td>
                     </tr>
@@ -439,6 +486,50 @@ async function persistQ5DayValue(day: number) {
                     <tr class="bg-muted/30">
                         <td class="px-3 py-2 font-semibold" colspan="2">Aufgabe 5 Gesamt</td>
                         <td class="px-3 py-2 font-bold">{{ questionFiveTotal }} / 8</td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+
+        <h3 class="text-lg font-semibold">BT – Aufgabe 6 (Scoring)</h3>
+        <p class="text-sm text-muted-foreground">
+            Punktvergabe: Ansatz ohne Telefon = 2 P.; Ansatz mit Telefon = 4 P.; Auftrag erledigt umständlich ohne Telefon = 6 P.; umständlich mit
+            Telefon = 7 P.; Bestzeit (Benachrichtigung ohne Rückweg zur Wohnung) = 8 P.
+        </p>
+        <p class="text-sm text-muted-foreground">
+            Hinweis: Bei reiner Namenseintragung ohne Zahlenangaben mit Skizze vergleichen und die passende RW-Stufe vergeben.
+        </p>
+        <div class="overflow-x-auto">
+            <table class="min-w-full rounded-lg border text-sm shadow">
+                <thead class="bg-muted/40">
+                    <tr>
+                        <th class="px-3 py-2 text-left">Lösungsstufe</th>
+                        <th class="px-3 py-2 text-left">Bewertung</th>
+                        <th class="px-3 py-2 text-left">Punkte</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="option in q6OptionEntries" :key="option.key">
+                        <td class="px-3 py-2">
+                            <input
+                                :checked="q6SelectedOption === option.key"
+                                type="radio"
+                                name="bt-q6-score-option"
+                                class="h-4 w-4 align-middle"
+                                @change="setQ6Option(option.key)"
+                            />
+                        </td>
+                        <td class="px-3 py-2">
+                            <div class="font-medium">{{ option.label }}</div>
+                            <div class="text-xs text-muted-foreground">{{ option.description }}</div>
+                        </td>
+                        <td class="px-3 py-2 font-semibold">{{ option.points }} / {{ option.points }}</td>
+                    </tr>
+                </tbody>
+                <tfoot>
+                    <tr class="bg-muted/30">
+                        <td class="px-3 py-2 font-semibold" colspan="2">Aufgabe 6 Gesamt</td>
+                        <td class="px-3 py-2 font-bold">{{ questionSixTotal }} / 8</td>
                     </tr>
                 </tfoot>
             </table>


### PR DESCRIPTION
### Motivation
- Provide an explicit manual-scoring UI and persisted field for BT task "Aufgabe 6" so examiners can reliably record the five-step rubric (2 / 4 / 6 / 7 / 8 points) and restore previously saved selections.

### Description
- Added a persistent manual-score key `bt_q6_score` and an option-to-points mapping for the five rubric levels inside `resources/js/components/BtResult.vue`.
- Implemented UI radio controls and descriptive labels for each rubric level and a computed `questionSixTotal` so the Aufgabe 6 score is shown as a total out of 8 points.
- Wired hydration so previously saved `bt_q6_score` values reselect the correct rubric option and the selected option is saved via the existing manual-score endpoint using `persistValue` / `persistQ6Value` and `setQ6Option`.
- Kept the scoring note about comparing name-only entries with the sketch and included the rubric descriptions to match the supplied scoring rules.

### Testing
- Ran `npx eslint resources/js/components/BtResult.vue` and it completed successfully.
- Ran `npx prettier --check resources/js/components/BtResult.vue` and fixed formatting with `npx prettier --write`, after which `prettier --check` reported no issues.
- Verified the change compiles in the development lint/format pipeline; the modified file is `resources/js/components/BtResult.vue`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de217df84083299cb22c65026b52ab)