### PR TITLE
BT: Implement Aufgabe 6 phone-aware scoring and Bestzeit evaluation

### DIFF
--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -494,6 +494,9 @@ const debugScores = computed(() => {
     },
   };
 });
+if (import.meta.env.DEV) {
+  (globalThis as { __btDebugScores?: unknown }).__btDebugScores = debugScores;
+}
 </script>
 
 <template>
@@ -502,62 +505,6 @@ const debugScores = computed(() => {
     <div v-if="showTest" class="absolute right-6 top-4 flex items-center gap-2">
       <Button variant="outline" @click="prevPage" :disabled="page === 1">Zurück</Button>
       <Button @click="nextPage" :disabled="page === maxPage">Weiter</Button>
-    </div>
-    <div
-      v-if="showTest"
-      class="absolute bottom-4 right-4 z-20 w-[900px] max-w-[calc(100%-2rem)] rounded-lg border border-black bg-white/95 p-3 font-sans text-xs shadow-lg"
-    >
-      <div class="mb-2 font-semibold">DEV: Dynamische Punkte (temporär, horizontal)</div>
-      <div class="grid grid-cols-6 gap-2">
-        <div class="rounded border border-black/20 px-2 py-1">
-          <div class="font-semibold">A1</div>
-          <div class="font-bold">{{ debugScores.q1.points }}/9</div>
-          <div class="text-[10px] text-muted-foreground">
-            F2 {{ debugScores.q1.earlyTwoSyllable }}/9 · F3 {{ debugScores.q1.earlyThreeSyllable }}/1
-          </div>
-          <div class="text-[10px] text-muted-foreground">
-            S1 {{ debugScores.q1.lateOneSyllable }}/8 · S3 {{ debugScores.q1.lateThreeSyllable }}/7
-          </div>
-        </div>
-        <div class="rounded border border-black/20 px-2 py-1">
-          <div class="font-semibold">A2</div>
-          <div class="font-bold">—</div>
-          <div class="text-[10px] text-muted-foreground">{{ debugScores.q2.note }}</div>
-        </div>
-        <div class="rounded border border-black/20 px-2 py-1">
-          <div class="font-semibold">A3</div>
-          <div class="font-bold">{{ debugScores.q3.points }}/{{ debugScores.q3.max }}</div>
-          <div class="text-[10px] text-muted-foreground">richtige Felder</div>
-        </div>
-        <div class="rounded border border-black/20 px-2 py-1">
-          <div class="font-semibold">A4</div>
-          <div class="font-bold">{{ debugScores.q4.points }}/{{ debugScores.q4.max }}</div>
-          <div class="text-[10px] text-muted-foreground">
-            Ordner mit 10%: {{ debugScores.q4.correctFolders }}/10
-          </div>
-          <div class="text-[10px] text-muted-foreground">
-            Alpha {{ debugScores.q4.alphabeticalOrderMet ? '✓' : '✗' }} · Reihenfolge {{ debugScores.q4.folderOrderMet ? '✓' : '✗' }}
-          </div>
-          <div class="text-[10px] text-muted-foreground">
-            Gewichte: {{ debugScores.q4.folderWeights.join(' / ') }}
-          </div>
-        </div>
-        <div class="rounded border border-black/20 px-2 py-1">
-          <div class="font-semibold">A5</div>
-          <div class="font-bold">{{ debugScores.q5.points }}/{{ debugScores.q5.max }}</div>
-          <div class="text-[10px] text-muted-foreground">5.AT=2 · 7.AT=2 · 10.AT=4</div>
-        </div>
-        <div class="rounded border border-black/20 px-2 py-1">
-          <div class="font-semibold">A6</div>
-          <div class="font-bold">{{ debugScores.q6.points }}/{{ debugScores.q6.max }}</div>
-          <div class="text-[10px] text-muted-foreground">
-            Reihen korrekt: {{ debugScores.q6.rowCorrectCount }} · Alle 6: {{ debugScores.q6.allPeopleNotified ? '✓' : '✗' }}
-          </div>
-          <div class="text-[10px] text-muted-foreground">
-            Tel: {{ debugScores.q6.hasPhoneUsage ? '✓' : '✗' }} · Bestzeit: {{ debugScores.q6.isBestTime ? '✓' : '✗' }}
-          </div>
-        </div>
-      </div>
     </div>
     <div v-if="!showTest" class="flex h-full items-center justify-center px-6">
       <div class="max-w-5xl space-y-6 rounded-2xl border border-black/20 bg-white p-8 font-serif text-base leading-relaxed shadow-sm">

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -506,6 +506,62 @@ if (import.meta.env.DEV) {
       <Button variant="outline" @click="prevPage" :disabled="page === 1">Zurück</Button>
       <Button @click="nextPage" :disabled="page === maxPage">Weiter</Button>
     </div>
+    <div
+      v-if="showTest"
+      class="absolute bottom-4 left-4 z-20 w-[900px] max-w-[calc(100%-2rem)] rounded-lg border border-black bg-white/95 p-3 font-sans text-xs shadow-lg"
+    >
+      <div class="mb-2 font-semibold">DEV: Dynamische Punkte (temporär, horizontal)</div>
+      <div class="grid grid-cols-6 gap-2">
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A1</div>
+          <div class="font-bold">{{ debugScores.q1.points }}/9</div>
+          <div class="text-[10px] text-muted-foreground">
+            F2 {{ debugScores.q1.earlyTwoSyllable }}/9 · F3 {{ debugScores.q1.earlyThreeSyllable }}/1
+          </div>
+          <div class="text-[10px] text-muted-foreground">
+            S1 {{ debugScores.q1.lateOneSyllable }}/8 · S3 {{ debugScores.q1.lateThreeSyllable }}/7
+          </div>
+        </div>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A2</div>
+          <div class="font-bold">—</div>
+          <div class="text-[10px] text-muted-foreground">{{ debugScores.q2.note }}</div>
+        </div>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A3</div>
+          <div class="font-bold">{{ debugScores.q3.points }}/{{ debugScores.q3.max }}</div>
+          <div class="text-[10px] text-muted-foreground">richtige Felder</div>
+        </div>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A4</div>
+          <div class="font-bold">{{ debugScores.q4.points }}/{{ debugScores.q4.max }}</div>
+          <div class="text-[10px] text-muted-foreground">
+            Ordner mit 10%: {{ debugScores.q4.correctFolders }}/10
+          </div>
+          <div class="text-[10px] text-muted-foreground">
+            Alpha {{ debugScores.q4.alphabeticalOrderMet ? '✓' : '✗' }} · Reihenfolge {{ debugScores.q4.folderOrderMet ? '✓' : '✗' }}
+          </div>
+          <div class="text-[10px] text-muted-foreground">
+            Gewichte: {{ debugScores.q4.folderWeights.join(' / ') }}
+          </div>
+        </div>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A5</div>
+          <div class="font-bold">{{ debugScores.q5.points }}/{{ debugScores.q5.max }}</div>
+          <div class="text-[10px] text-muted-foreground">5.AT=2 · 7.AT=2 · 10.AT=4</div>
+        </div>
+        <div class="rounded border border-black/20 px-2 py-1">
+          <div class="font-semibold">A6</div>
+          <div class="font-bold">{{ debugScores.q6.points }}/{{ debugScores.q6.max }}</div>
+          <div class="text-[10px] text-muted-foreground">
+            Reihen korrekt: {{ debugScores.q6.rowCorrectCount }} · Alle 6: {{ debugScores.q6.allPeopleNotified ? '✓' : '✗' }}
+          </div>
+          <div class="text-[10px] text-muted-foreground">
+            Tel: {{ debugScores.q6.hasPhoneUsage ? '✓' : '✗' }} · Bestzeit: {{ debugScores.q6.isBestTime ? '✓' : '✗' }}
+          </div>
+        </div>
+      </div>
+    </div>
     <div v-if="!showTest" class="flex h-full items-center justify-center px-6">
       <div class="max-w-5xl space-y-6 rounded-2xl border border-black/20 bg-white p-8 font-serif text-base leading-relaxed shadow-sm">
         <h1 class="text-center text-2xl font-semibold tracking-[0.2em]">EINFÜHRUNG</h1>

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -114,6 +114,9 @@ const routeTimes = ref<Record<string, string>>(
     ]),
   ),
 );
+const routePhoneUsage = ref<Record<string, boolean>>(
+  Object.fromEntries(routeRows.map((row) => [`route-phone-${row}`, false])),
+);
 const routeTotals = ref({ totalWay: '', totalMsg: '', returnWay: '' });
 const q3ExpectedCashCounts: Record<string, number> = {
   '100': 64,
@@ -267,6 +270,10 @@ function handleRouteTotalInput(key: 'totalWay' | 'totalMsg' | 'returnWay', event
   target.value = cleaned;
 }
 
+function toggleRoutePhoneUsage(row: number) {
+  routePhoneUsage.value[`route-phone-${row}`] = !routePhoneUsage.value[`route-phone-${row}`];
+}
+
 function nextPage() {
   if (page.value < maxPage) {
     page.value += 1;
@@ -331,6 +338,96 @@ function evaluateQ4() {
 }
 
 const debugScores = computed(() => {
+  const q6TravelTimes: Record<string, number> = {
+    'Eigene Wohnung|Frey': 5,
+    'Frey|Eigene Wohnung': 5,
+    'Eigene Wohnung|Fuchs': 15,
+    'Fuchs|Eigene Wohnung': 15,
+    'Eigene Wohnung|Hermann': 8,
+    'Hermann|Eigene Wohnung': 8,
+    'Eigene Wohnung|Schneider': 5,
+    'Schneider|Eigene Wohnung': 5,
+    'Müller|Frey': 5,
+    'Frey|Müller': 5,
+    'Müller|Fuchs': 20,
+    'Fuchs|Müller': 20,
+    'Frey|Bär': 5,
+    'Bär|Frey': 5,
+    'Frey|Hermann': 5,
+    'Hermann|Frey': 5,
+    'Frey|Schneider': 12,
+    'Schneider|Frey': 12,
+    'Bär|Hermann': 5,
+    'Hermann|Bär': 5,
+    'Hermann|Schneider': 5,
+    'Schneider|Hermann': 5,
+    'Fuchs|Schneider': 15,
+    'Schneider|Fuchs': 15,
+  };
+  const q6PhoneLocations = new Set(['Müller', 'Bär', 'Hermann', 'Schneider']);
+  const q6ExpectedPeople = new Set(['Müller', 'Frey', 'Bär', 'Hermann', 'Schneider', 'Fuchs']);
+
+  let currentLocation = 'Eigene Wohnung';
+  let rowCorrectCount = 0;
+  let hasPhoneUsage = false;
+  let hasAnyCorrectRow = false;
+  const notifiedPeople = new Set<string>();
+
+  routeRows.forEach((row) => {
+    const fromRaw = (routeAssignments.value[`route-from-${row}`] ?? '').trim();
+    const toRaw = (routeAssignments.value[`route-to-${row}`] ?? '').trim();
+    const effectiveFrom = fromRaw || currentLocation;
+    const wayRaw = routeTimes.value[`route-time-${row}`];
+    const msgRaw = routeTimes.value[`route-msg-${row}`];
+    const isPhoneRow = routePhoneUsage.value[`route-phone-${row}`] === true;
+
+    if (!toRaw) return;
+
+    const msgOk = Number(msgRaw) === 3;
+    let rowOk = false;
+
+    if (isPhoneRow) {
+      hasPhoneUsage = true;
+      const wayOk = wayRaw === '' || Number(wayRaw) === 0;
+      const fromHasPhone = q6PhoneLocations.has(effectiveFrom);
+      const toHasPhone = q6PhoneLocations.has(toRaw);
+      const fromMatchesLocation = effectiveFrom === currentLocation;
+      rowOk = wayOk && msgOk && fromHasPhone && toHasPhone && fromMatchesLocation;
+      if (rowOk) {
+        notifiedPeople.add(toRaw);
+      }
+    } else {
+      const expectedTravelTime = q6TravelTimes[`${effectiveFrom}|${toRaw}`];
+      const wayOk = Number(wayRaw) === expectedTravelTime;
+      rowOk = Number.isFinite(expectedTravelTime) && wayOk && msgOk;
+      if (rowOk) {
+        notifiedPeople.add(toRaw);
+        currentLocation = toRaw;
+      }
+    }
+
+    if (rowOk) {
+      rowCorrectCount += 1;
+      hasAnyCorrectRow = true;
+    }
+  });
+
+  const allPeopleNotified = [...q6ExpectedPeople].every((name) => notifiedPeople.has(name));
+  const fullyCorrectCompletion = allPeopleNotified && rowCorrectCount >= 6;
+  const totalWay = Number(routeTotals.value.totalWay);
+  const totalMsg = Number(routeTotals.value.totalMsg);
+  const returnWay = Number(routeTotals.value.returnWay);
+  const isBestTime = fullyCorrectCompletion && hasPhoneUsage && totalWay === 30 && totalMsg === 18 && returnWay === 15;
+
+  let q6Points = 0;
+  if (isBestTime) {
+    q6Points = 8;
+  } else if (fullyCorrectCompletion) {
+    q6Points = hasPhoneUsage ? 7 : 6;
+  } else if (hasAnyCorrectRow) {
+    q6Points = hasPhoneUsage ? 4 : 2;
+  }
+
   const earlyAssigned = Object.entries(assignments.value)
     .filter(([key, value]) => key.startsWith('early-') && value)
     .map(([, value]) => value as string);
@@ -386,9 +483,14 @@ const debugScores = computed(() => {
       correctDays: q5CorrectDays,
     },
     q6: {
-      points: routeRows.filter((row) => routeAssignments.value[`route-to-${row}`]).length,
-      max: 6,
-      note: 'Nur Eingabe-Check für Reihenfolge (kein Optimalitäts-Check).',
+      points: q6Points,
+      max: 8,
+      hasPhoneUsage,
+      hasAnyCorrectRow,
+      rowCorrectCount,
+      allPeopleNotified,
+      fullyCorrectCompletion,
+      isBestTime,
     },
   };
 });
@@ -448,7 +550,12 @@ const debugScores = computed(() => {
         <div class="rounded border border-black/20 px-2 py-1">
           <div class="font-semibold">A6</div>
           <div class="font-bold">{{ debugScores.q6.points }}/{{ debugScores.q6.max }}</div>
-          <div class="text-[10px] text-muted-foreground">Eingabe-Check</div>
+          <div class="text-[10px] text-muted-foreground">
+            Reihen korrekt: {{ debugScores.q6.rowCorrectCount }} · Alle 6: {{ debugScores.q6.allPeopleNotified ? '✓' : '✗' }}
+          </div>
+          <div class="text-[10px] text-muted-foreground">
+            Tel: {{ debugScores.q6.hasPhoneUsage ? '✓' : '✗' }} · Bestzeit: {{ debugScores.q6.isBestTime ? '✓' : '✗' }}
+          </div>
         </div>
       </div>
     </div>
@@ -1405,7 +1512,7 @@ const debugScores = computed(() => {
                     </div>
                   </td>
                   <td class="border-r border-black px-2">
-                    <div class="flex items-center justify-end gap-2 pr-8">
+                    <div class="flex items-center justify-end gap-3 pr-4">
                       <input
                         :value="routeTimes[`route-time-${row}`]"
                         type="text"
@@ -1415,6 +1522,15 @@ const debugScores = computed(() => {
                         @input="(event) => handleRouteTimeInput(`route-time-${row}`, event)"
                       />
                       <span class="w-8">Min.</span>
+                      <label class="flex items-center gap-1 text-xs whitespace-nowrap">
+                        <input
+                          :checked="routePhoneUsage[`route-phone-${row}`]"
+                          type="checkbox"
+                          class="h-3.5 w-3.5"
+                          @change="() => toggleRoutePhoneUsage(row)"
+                        />
+                        Telefonisch
+                      </label>
                     </div>
                   </td>
                   <td class="px-2">


### PR DESCRIPTION
### Motivation
- Add full, rule-faithful automatic scoring for BT Aufgabe 6 so the app can grade user routes against the paper rules (Ansatz vs. erledigt, phone usage, Bestzeit).
- Detect phone usage per row and treat phone-calls differently from travelled visits as required by the scoring rules.
- Make the debug UI surface enough internal state to verify edge cases while developing the scoring.

### Description
- Implemented the Q6 scoring engine and diagnostics in `resources/js/pages/BT.vue`, including a travel-time lookup table for all relevant `von|nach` pairs and a set of phone-capable locations. 
- Added a per-row `Telefonisch` checkbox (UI next to the `Zeit (Weg)` input) and wired it to scoring logic that validates: message time equals `3`, calls only when caller and callee have phones, no travel time during a call row, and implicit `von` resolution to the current location when empty.
- Applied the exact point ladder: `2` = Ansatz without phone, `4` = Ansatz with phone, `6` = Auftrag erledigt without phone, `7` = Auftrag erledigt with phone (not Bestzeit), `8` = Bestzeit when completion is correct and totals match `Weg=30`, `Nachr.=18`, `Rückweg=15` (totals are taken from user-entered total fields).
- Extended the developer debug card to expose `rowCorrectCount`, `allPeopleNotified`, `hasPhoneUsage`, `fullyCorrectCompletion`, and `isBestTime` so graders can quickly inspect why a score was awarded.

### Testing
- Ran ESLint on the modified file with `npx eslint resources/js/pages/BT.vue`, which completed successfully.
- Manual in-page debug checks were added (visible in the A6 debug card) to exercise and observe scoring behavior during interactive testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5a9f20648329a9cbf6219139996c)