### PR TITLE
Prevent browser interference with spelling test options

### DIFF
--- a/resources/js/composables/useMrtA.ts
+++ b/resources/js/composables/useMrtA.ts
@@ -1,6 +1,9 @@
 import { computed } from 'vue';
 
 // --- Static Data ---
+// NOTE: Some words here (like "Heerschar" containing "rsch" or "Appetitt" containing "tit")
+// might trigger aggressive profanity filters or automatic translation tools in the browser.
+// Ensure the UI uses translate="no" and class="notranslate" on these options.
 const mrtQuestions = [
     { number: 1, options: ["Drehohrgel", "Dreohrgel", "Dreorgel", "Drehorgel"], correct: ["D"] },
   { number: 2, options: ["Spülmaschine", "Spühlmaschiene", "Spülmaschiene", "Spühlmaschine"], correct: ["A"] },

--- a/resources/js/composables/useMrtB.ts
+++ b/resources/js/composables/useMrtB.ts
@@ -1,4 +1,7 @@
 // --- Static Data ---
+// NOTE: Some words in these spelling tests might trigger aggressive profanity filters
+// or automatic translation tools in the browser.
+// Ensure the UI uses translate="no" and class="notranslate" on these options.
 const mrtBQuestions = [
     { number: 1, options: ['Dezimahlwaage', 'Dezimahlwage', 'Dezimalwaage', 'Dezimalwage'], correct: ['C'] },
     { number: 2, options: ['trübselig', 'trühbseelig', 'trübseelig', 'trübsehlig'], correct: ['A'] },

--- a/resources/js/pages/MRT-A.vue
+++ b/resources/js/pages/MRT-A.vue
@@ -283,7 +283,8 @@ const startTest = () => {
                     <div class="mb-6 flex flex-row gap-4">
                         <div v-for="(option, oidx) in currentQuestion.options" :key="oidx" class="flex flex-col items-center">
                             <button
-                                class="min-w-[120px] rounded-xl border px-4 py-3 font-sans text-base font-semibold transition"
+                                translate="no"
+                                class="notranslate min-w-[120px] rounded-xl border px-4 py-3 font-sans text-base font-semibold transition"
                                 :class="[
                                     userAnswers[currentQuestionIndex] === String.fromCharCode(65 + oidx)
                                         ? 'border-blue-700 bg-blue-300 text-blue-900 dark:bg-blue-900 dark:text-blue-100'

--- a/resources/js/pages/MRT-B.vue
+++ b/resources/js/pages/MRT-B.vue
@@ -282,7 +282,8 @@ const startTest = () => {
                     <div class="mb-6 flex flex-row gap-4">
                         <div v-for="(option, oidx) in currentQuestion.options" :key="oidx" class="flex flex-col items-center">
                             <button
-                                class="min-w-[120px] rounded-xl border px-4 py-3 font-sans text-base font-semibold transition"
+                                translate="no"
+                                class="notranslate min-w-[120px] rounded-xl border px-4 py-3 font-sans text-base font-semibold transition"
                                 :class="[
                                     userAnswers[currentQuestionIndex] === String.fromCharCode(65 + oidx)
                                         ? 'border-blue-700 bg-blue-300 text-blue-900 dark:bg-blue-900 dark:text-blue-100'

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="google" content="notranslate">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>


### PR DESCRIPTION
The reported issue where MRT-A options were replaced with words like "Fresse", "Prost", and "Vorspeise" was diagnosed as client-side interference from browser auto-translators and aggressive profanity filters. Specifically, substrings like "rsch" (in Heerschar) and "tit" (in Appetitt) can trigger these tools.

Changes:
- Added `translate="no"` and `class="notranslate"` to question buttons in `MRT-A.vue` and `MRT-B.vue`.
- Added `<meta name="google" content="notranslate">` to `app.blade.php` to discourage site-wide translation.
- Added developer comments in `useMrtA.ts` and `useMrtB.ts` to document the sensitivity of these words.

---
*PR created automatically by Jules for task [8190764888425047069](https://jules.google.com/task/8190764888425047069) started by @miqr-dev*