### PR TITLE
BT: allow name reuse in Aufgabe 1, remove pool "used" visuals, and implement first-appearance scoring

### DIFF
--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -60,7 +60,6 @@ const assignments = ref<Record<string, string | null>>(
   ),
 );
 
-const assignedNames = computed(() => new Set(Object.values(assignments.value).filter(Boolean)));
 const leftNames = computed(() => apprentices.value.slice(0, 13));
 const rightNames = computed(() => apprentices.value.slice(13));
 const maxPage = 6;
@@ -166,14 +165,6 @@ function buildCellKey(shift: 'early' | 'late', slot: number, day: string) {
   return `${shift}-${slot}-${day}`;
 }
 
-function clearNameFromAssignments(name: string) {
-  Object.keys(assignments.value).forEach((key) => {
-    if (assignments.value[key] === name) {
-      assignments.value[key] = null;
-    }
-  });
-}
-
 function handleDragStart(event: DragEvent, payload: DragPayload) {
   event.dataTransfer?.setData('text/plain', JSON.stringify(payload));
   event.dataTransfer?.setDragImage((event.target as HTMLElement) ?? document.body, 0, 0);
@@ -191,7 +182,6 @@ function handleDropOnCell(event: DragEvent, key: string) {
     assignments.value[payload.key] = null;
   }
 
-  clearNameFromAssignments(payload.name);
   assignments.value[key] = payload.name;
 }
 
@@ -203,7 +193,9 @@ function handleDropOnPool(event: DragEvent) {
   const payload = JSON.parse(payloadText) as DragPayload;
   if (!payload?.name) return;
 
-  clearNameFromAssignments(payload.name);
+  if (payload.from === 'cell' && payload.key) {
+    assignments.value[payload.key] = null;
+  }
 }
 
 function allowDrop(event: DragEvent) {
@@ -212,10 +204,6 @@ function allowDrop(event: DragEvent) {
 
 function clearCell(key: string) {
   assignments.value[key] = null;
-}
-
-function isAssigned(name: string) {
-  return assignedNames.value.has(name);
 }
 
 function handleCashInput(key: string, event: Event) {
@@ -457,17 +445,36 @@ const debugScores = computed(() => {
     q6Points = hasPhoneUsage ? 4 : 2;
   }
 
-  const earlyAssigned = Object.entries(assignments.value)
-    .filter(([key, value]) => key.startsWith('early-') && value)
-    .map(([, value]) => value as string);
-  const lateAssigned = Object.entries(assignments.value)
-    .filter(([key, value]) => key.startsWith('late-') && value)
-    .map(([, value]) => value as string);
+  const firstAppearanceNames = new Set<string>();
+  let earlyTwoSyllable = 0;
+  let earlyThreeSyllable = 0;
+  let lateOneSyllable = 0;
+  let lateThreeSyllable = 0;
 
-  const earlyTwoSyllable = earlyAssigned.filter((name) => twoSyllableNames.has(name)).length;
-  const earlyThreeSyllable = earlyAssigned.filter((name) => threeSyllableNames.has(name)).length;
-  const lateOneSyllable = lateAssigned.filter((name) => oneSyllableNames.has(name)).length;
-  const lateThreeSyllable = lateAssigned.filter((name) => threeSyllableNames.has(name)).length;
+  days.forEach((day) => {
+    const orderedSlots: Array<{ shift: 'early' | 'late'; slot: number }> = [
+      { shift: 'early', slot: 1 },
+      { shift: 'early', slot: 2 },
+      { shift: 'late', slot: 1 },
+      { shift: 'late', slot: 2 },
+      { shift: 'late', slot: 3 },
+    ];
+
+    orderedSlots.forEach(({ shift, slot }) => {
+      const key = buildCellKey(shift, slot, day);
+      const name = assignments.value[key];
+      if (!name || firstAppearanceNames.has(name)) return;
+
+      firstAppearanceNames.add(name);
+      if (shift === 'early') {
+        if (twoSyllableNames.has(name)) earlyTwoSyllable += 1;
+        if (threeSyllableNames.has(name)) earlyThreeSyllable += 1;
+      } else {
+        if (oneSyllableNames.has(name)) lateOneSyllable += 1;
+        if (threeSyllableNames.has(name)) lateThreeSyllable += 1;
+      }
+    });
+  });
 
   const q1Points =
     (earlyTwoSyllable === 9 ? 3 : 0) +
@@ -660,9 +667,7 @@ if (import.meta.env.DEV) {
                     <div class="space-y-0">
                       <div v-for="apprentice in leftNames" :key="apprentice.id" class="flex items-center gap-2">
                         <span class="w-6 text-right flex-none">{{ apprentice.id }}</span>
-                        <span class="flex-1 text-left text-xl"
-                          :class="{ 'line-through text-gray-500': isAssigned(apprentice.name) }"
-                          :draggable="!isAssigned(apprentice.name)"
+                        <span class="flex-1 text-left text-xl" draggable="true"
                           @dragstart="(event) => handleDragStart(event, { name: apprentice.name, from: 'pool' })">
                           {{ apprentice.name }}
                         </span>
@@ -672,9 +677,7 @@ if (import.meta.env.DEV) {
                     <div class="space-y-0">
                       <div v-for="apprentice in rightNames" :key="apprentice.id" class="flex items-center gap-2">
                         <span class="w-6 text-right flex-none">{{ apprentice.id }}</span>
-                        <span class="flex-1 text-left"
-                          :class="{ 'line-through text-gray-500': isAssigned(apprentice.name) }"
-                          :draggable="!isAssigned(apprentice.name)"
+                        <span class="flex-1 text-left" draggable="true"
                           @dragstart="(event) => handleDragStart(event, { name: apprentice.name, from: 'pool' })">
                           {{ apprentice.name }}
                         </span>

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -177,6 +177,8 @@ function handleDropOnCell(event: DragEvent, key: string) {
 
   const payload = JSON.parse(payloadText) as DragPayload;
   if (!payload?.name) return;
+  const targetValue = assignments.value[key];
+  if (targetValue && payload.key !== key) return;
 
   if (payload.from === 'cell' && payload.key) {
     assignments.value[payload.key] = null;


### PR DESCRIPTION
### Motivation
- Pool names must remain reusable and show no visual hint when used, because the task should not help the user by disabling or striking-through names. 
- Dragging from the pool should behave as a copy (pool stays unchanged) while dragging between cells should still move the name. 
- Scoring must keep the original rule that the first appearance of a name counts as correct and subsequent appearances are wrong, with the first-appearance calculated in the weekly order (Monday → Friday, Early1, Early2, Late1, Late2, Late3).

### Description
- Removed the global `assignedNames` computed and the `isAssigned` / `clearNameFromAssignments` usage and changed the pool rendering so pool items are always `draggable="true"` and no longer render a `line-through` or gray styling. 
- Updated `handleDropOnCell` and `handleDropOnPool` so the source cell is only cleared when the drag payload indicates it came `from: 'cell'`, effectively making pool drags copy and cell drags move. 
- Reworked the Q1 scoring inside the `debugScores` computed: iterate `days` in weekly order and for each slot check assignments and only count the first appearance of each name using a `firstAppearanceNames` set, incrementing `earlyTwoSyllable`, `earlyThreeSyllable`, `lateOneSyllable`, and `lateThreeSyllable` accordingly. 
- Changes are contained in `resources/js/pages/BT.vue` and adjust UI behavior and scoring logic consistently.

### Testing
- Ran `npx eslint resources/js/pages/BT.vue`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86e346bc08329ba18cf79e3723070)