### PR TITLE
Refactor drag/drop assignment logic and scoring to use first-appearance and simplify pool interactions

### DIFF
--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -60,7 +60,6 @@ const assignments = ref<Record<string, string | null>>(
   ),
 );
 
-const assignedNames = computed(() => new Set(Object.values(assignments.value).filter(Boolean)));
 const leftNames = computed(() => apprentices.value.slice(0, 13));
 const rightNames = computed(() => apprentices.value.slice(13));
 const maxPage = 6;
@@ -166,14 +165,6 @@ function buildCellKey(shift: 'early' | 'late', slot: number, day: string) {
   return `${shift}-${slot}-${day}`;
 }
 
-function clearNameFromAssignments(name: string) {
-  Object.keys(assignments.value).forEach((key) => {
-    if (assignments.value[key] === name) {
-      assignments.value[key] = null;
-    }
-  });
-}
-
 function handleDragStart(event: DragEvent, payload: DragPayload) {
   event.dataTransfer?.setData('text/plain', JSON.stringify(payload));
   event.dataTransfer?.setDragImage((event.target as HTMLElement) ?? document.body, 0, 0);
@@ -186,12 +177,13 @@ function handleDropOnCell(event: DragEvent, key: string) {
 
   const payload = JSON.parse(payloadText) as DragPayload;
   if (!payload?.name) return;
+  const targetValue = assignments.value[key];
+  if (targetValue && payload.key !== key) return;
 
   if (payload.from === 'cell' && payload.key) {
     assignments.value[payload.key] = null;
   }
 
-  clearNameFromAssignments(payload.name);
   assignments.value[key] = payload.name;
 }
 
@@ -203,7 +195,9 @@ function handleDropOnPool(event: DragEvent) {
   const payload = JSON.parse(payloadText) as DragPayload;
   if (!payload?.name) return;
 
-  clearNameFromAssignments(payload.name);
+  if (payload.from === 'cell' && payload.key) {
+    assignments.value[payload.key] = null;
+  }
 }
 
 function allowDrop(event: DragEvent) {
@@ -212,10 +206,6 @@ function allowDrop(event: DragEvent) {
 
 function clearCell(key: string) {
   assignments.value[key] = null;
-}
-
-function isAssigned(name: string) {
-  return assignedNames.value.has(name);
 }
 
 function handleCashInput(key: string, event: Event) {
@@ -457,17 +447,36 @@ const debugScores = computed(() => {
     q6Points = hasPhoneUsage ? 4 : 2;
   }
 
-  const earlyAssigned = Object.entries(assignments.value)
-    .filter(([key, value]) => key.startsWith('early-') && value)
-    .map(([, value]) => value as string);
-  const lateAssigned = Object.entries(assignments.value)
-    .filter(([key, value]) => key.startsWith('late-') && value)
-    .map(([, value]) => value as string);
+  const firstAppearanceNames = new Set<string>();
+  let earlyTwoSyllable = 0;
+  let earlyThreeSyllable = 0;
+  let lateOneSyllable = 0;
+  let lateThreeSyllable = 0;
 
-  const earlyTwoSyllable = earlyAssigned.filter((name) => twoSyllableNames.has(name)).length;
-  const earlyThreeSyllable = earlyAssigned.filter((name) => threeSyllableNames.has(name)).length;
-  const lateOneSyllable = lateAssigned.filter((name) => oneSyllableNames.has(name)).length;
-  const lateThreeSyllable = lateAssigned.filter((name) => threeSyllableNames.has(name)).length;
+  const orderedSlots: Array<{ shift: 'early' | 'late'; slot: number }> = [
+    { shift: 'early', slot: 1 },
+    { shift: 'early', slot: 2 },
+    { shift: 'late', slot: 1 },
+    { shift: 'late', slot: 2 },
+    { shift: 'late', slot: 3 },
+  ];
+
+  orderedSlots.forEach(({ shift, slot }) => {
+    days.forEach((day) => {
+      const key = buildCellKey(shift, slot, day);
+      const name = assignments.value[key];
+      if (!name || firstAppearanceNames.has(name)) return;
+
+      firstAppearanceNames.add(name);
+      if (shift === 'early') {
+        if (twoSyllableNames.has(name)) earlyTwoSyllable += 1;
+        if (threeSyllableNames.has(name)) earlyThreeSyllable += 1;
+      } else {
+        if (oneSyllableNames.has(name)) lateOneSyllable += 1;
+        if (threeSyllableNames.has(name)) lateThreeSyllable += 1;
+      }
+    });
+  });
 
   const q1Points =
     (earlyTwoSyllable === 9 ? 3 : 0) +
@@ -660,9 +669,7 @@ if (import.meta.env.DEV) {
                     <div class="space-y-0">
                       <div v-for="apprentice in leftNames" :key="apprentice.id" class="flex items-center gap-2">
                         <span class="w-6 text-right flex-none">{{ apprentice.id }}</span>
-                        <span class="flex-1 text-left text-xl"
-                          :class="{ 'line-through text-gray-500': isAssigned(apprentice.name) }"
-                          :draggable="!isAssigned(apprentice.name)"
+                        <span class="flex-1 text-left text-xl" draggable="true"
                           @dragstart="(event) => handleDragStart(event, { name: apprentice.name, from: 'pool' })">
                           {{ apprentice.name }}
                         </span>
@@ -672,9 +679,7 @@ if (import.meta.env.DEV) {
                     <div class="space-y-0">
                       <div v-for="apprentice in rightNames" :key="apprentice.id" class="flex items-center gap-2">
                         <span class="w-6 text-right flex-none">{{ apprentice.id }}</span>
-                        <span class="flex-1 text-left"
-                          :class="{ 'line-through text-gray-500': isAssigned(apprentice.name) }"
-                          :draggable="!isAssigned(apprentice.name)"
+                        <span class="flex-1 text-left" draggable="true"
                           @dragstart="(event) => handleDragStart(event, { name: apprentice.name, from: 'pool' })">
                           {{ apprentice.name }}
                         </span>


### PR DESCRIPTION
### Motivation

- Simplify and harden drag/drop behavior for assigning apprentices to shifts by removing global assigned-name tracking and relying on per-cell operations.
- Prevent incorrect scoring when a name appears multiple times by ensuring only the first appearance in the schedule is counted for Q1 metrics.
- Make the pool list always draggable and remove the visual-disabled state so assignment behavior is consistent and driven by drop handlers.

### Description

- Removed the `assignedNames` computed value, the `isAssigned` helper, and `clearNameFromAssignments` function, and replaced global clearing with targeted clears when a drag originates from a cell (`payload.from === 'cell'`).
- Updated `handleDropOnCell` to block dropping into an occupied target unless the drag comes from the same cell by checking the target value and `payload.key`.
- Changed pool list rendering to always set `draggable="true"` and to send `{ from: 'pool' }` on drag start, removing the line-through/disabled UI for already assigned names.
- Rewrote the Q1 scoring computation to iterate ordered slots and count only the first appearance of each name (`firstAppearanceNames`), and calculate syllable-based counters (`earlyTwoSyllable`, `earlyThreeSyllable`, `lateOneSyllable`, `lateThreeSyllable`) accordingly.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86e346bc08329ba18cf79e3723070)