### PR TITLE
BT: result tables, manual scoring for Aufgabe 2, 60‑minute test and "Test beenden"

### DIFF
--- a/database/seeders/TestsTableSeeder.php
+++ b/database/seeders/TestsTableSeeder.php
@@ -22,6 +22,7 @@ class TestsTableSeeder extends Seeder
       ['name' => 'LPS-B', 'code' => 'LPS-B', 'duration' => 25],
       ['name' => 'LPS',   'code' => 'LPS', 'duration' => 25],
       ['name' => 'BIT-2', 'code' => 'BIT-2', 'duration' => 15],
+      ['name' => 'BT', 'code' => 'BT', 'duration' => 60],
       ['name' => 'AVEM', 'code' => 'AVEM', 'duration' => 20],
       ['name' => 'Konzentrationstest', 'code' => 'Konzentrationstest', 'duration' => 6],
       ['name' => 'LPS-B', 'code' => 'LPS-B', 'duration' => 60],

--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -8,10 +8,12 @@ const props = withDefaults(
     testResultId?: number | null;
     manualScores?: Record<string, number | string | null>;
     results?: Record<string, any> | null;
+    showAnswers?: boolean;
   }>(),
   {
     manualScores: () => ({}),
     results: null,
+    showAnswers: true,
   },
 );
 
@@ -20,8 +22,18 @@ const emit = defineEmits<{
 }>();
 
 const q2ManualScoreKey = 'bt_q2_manual_points';
-const q2ManualPoints = ref('');
+const q2ManualPointsInput = ref('');
 const days = ['Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag'];
+const q3Denominations = [
+  { key: '100', label: '100€', expected: 64 },
+  { key: '50', label: '50€', expected: 3 },
+  { key: '20', label: '20€', expected: 6 },
+  { key: '10', label: '10€', expected: 3 },
+  { key: '5', label: '5€', expected: 3 },
+  { key: '2', label: '2€', expected: 4 },
+  { key: '1', label: '1€', expected: 5 },
+  { key: '0.5', label: '0,50€', expected: 4 },
+] as const;
 
 const q1Assignments = computed<Record<string, string | null>>(() => props.results?.assignments ?? {});
 const q3CashAnswers = computed<Record<string, string>>(() => props.results?.cash_answers ?? {});
@@ -30,29 +42,191 @@ const q5StampDays = computed<Record<number, boolean>>(() => props.results?.stamp
 const q6RouteAssignments = computed<Record<string, string | null>>(() => props.results?.route_assignments ?? {});
 const q6RouteTimes = computed<Record<string, string>>(() => props.results?.route_times ?? {});
 const q6RouteTotals = computed<Record<string, string>>(() => props.results?.route_totals ?? {});
+const q6Scoring = computed(() => props.results?.scoring?.q6 ?? null);
 
 watch(
   () => props.manualScores,
   (next) => {
     const raw = next?.[q2ManualScoreKey];
-    q2ManualPoints.value = raw == null || raw === '' ? '' : `${raw}`;
+    q2ManualPointsInput.value = raw == null || raw === '' ? '' : `${raw}`;
   },
   { immediate: true, deep: true },
 );
+
+const q2ManualPoints = computed(() => {
+  if (q2ManualPointsInput.value === '') return null;
+  const parsed = Number(q2ManualPointsInput.value);
+  return Number.isFinite(parsed) ? parsed : null;
+});
+
+const oneSyllableNames = new Set(['Fuchs', 'Hans', 'Kurz', 'Mann', 'Pahl', 'Paul', 'Pees', 'Roth']);
+const twoSyllableNames = new Set(['Basten', 'Bauer', 'Bertram', 'Bolte', 'Krämer', 'Kühne', 'Müller', 'Schneider', 'Schuster']);
+const threeSyllableNames = new Set(['Angermann', 'Berkelhahn', 'Diesterweg', 'Eschweiler', 'Hamburger', 'Hamelring', 'Kleininger', 'Petersen']);
 
 function buildCellKey(shift: 'early' | 'late', slot: number, day: string) {
   return `${shift}-${slot}-${day}`;
 }
 
+function toNumber(value: unknown): number | null {
+  if (value == null || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatTime(seconds?: number | null) {
+  if (seconds == null || !Number.isFinite(seconds)) return '–';
+  const total = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+const q1Stats = computed(() => {
+  const orderedSlots: Array<{ shift: 'early' | 'late'; slot: number }> = [
+    { shift: 'early', slot: 1 },
+    { shift: 'early', slot: 2 },
+    { shift: 'late', slot: 1 },
+    { shift: 'late', slot: 2 },
+    { shift: 'late', slot: 3 },
+  ];
+  const firstAppearanceNames = new Set<string>();
+  let earlyTwoSyllable = 0;
+  let earlyThreeSyllable = 0;
+  let lateOneSyllable = 0;
+  let lateThreeSyllable = 0;
+
+  orderedSlots.forEach(({ shift, slot }) => {
+    days.forEach((day) => {
+      const name = q1Assignments.value[buildCellKey(shift, slot, day)];
+      if (!name || firstAppearanceNames.has(name)) return;
+      firstAppearanceNames.add(name);
+
+      if (shift === 'early') {
+        if (twoSyllableNames.has(name)) earlyTwoSyllable += 1;
+        if (threeSyllableNames.has(name)) earlyThreeSyllable += 1;
+      } else {
+        if (oneSyllableNames.has(name)) lateOneSyllable += 1;
+        if (threeSyllableNames.has(name)) lateThreeSyllable += 1;
+      }
+    });
+  });
+
+  const points = (earlyTwoSyllable === 9 ? 3 : 0) + (earlyThreeSyllable === 1 ? 1 : 0) + (lateOneSyllable === 8 ? 3 : 0) + (lateThreeSyllable === 7 ? 2 : 0);
+
+  return { earlyTwoSyllable, earlyThreeSyllable, lateOneSyllable, lateThreeSyllable, points, max: 9 };
+});
+
+const q3Score = computed(() => {
+  const mistakes = q3Denominations
+    .map((denomination) => {
+      const actual = toNumber(q3CashAnswers.value[denomination.key]);
+      if (actual === denomination.expected) return null;
+      return `${denomination.label}: ${actual ?? 'leer'} statt ${denomination.expected}`;
+    })
+    .filter((value): value is string => value !== null);
+
+  return { points: q3Denominations.length - mistakes.length, max: q3Denominations.length, mistakes };
+});
+
+const btAlphabet = 'ABCDEFGHJKLMNOPQRSTUVWXYZ';
+const q4LetterWeights: Record<string, number> = {
+  A: 15, F: 15, W: 15, B: 15, G: 15, J: 15, X: 15, Y: 15, C: 15, H: 15, Z: 15, D: 15,
+  R: 20, P: 20, Q: 20,
+  N: 30, K: 30, S: 30, V: 30, T: 30, U: 30, O: 30, L: 30,
+  M: 60, E: 60,
+};
+
+function normalizeFolderLetters(value: string) {
+  return value
+    .toUpperCase()
+    .replace(/[^A-Z]/g, '')
+    .split('')
+    .filter((char, index, arr) => btAlphabet.includes(char) && arr.indexOf(char) === index);
+}
+
+function isAlphabetical(chars: string[]) {
+  return chars.every((char, index) => index === 0 || btAlphabet.indexOf(chars[index - 1]) <= btAlphabet.indexOf(char));
+}
+
+const q4Score = computed(() => {
+  const answers = Array.from({ length: 10 }, (_, index) => normalizeFolderLetters(String(q4FolderAnswers.value[index + 1] ?? '')));
+  const seenLetters = new Set<string>();
+  const folderWeights = answers.map((chars) =>
+    chars.reduce((sum, char) => {
+      if (seenLetters.has(char)) return sum;
+      seenLetters.add(char);
+      return sum + (q4LetterWeights[char] ?? 0);
+    }, 0),
+  );
+
+  const correctFolderCount = folderWeights.filter((weight) => weight === 60).length;
+  const alphabeticalOrderMet = answers.every((chars) => isAlphabetical(chars));
+  const folderOrderMet = answers.every((chars, index) => {
+    if (index === answers.length - 1) return true;
+    const currentIndices = chars.map((char) => btAlphabet.indexOf(char));
+    const nextIndices = answers[index + 1].map((char) => btAlphabet.indexOf(char));
+    if (!currentIndices.length || !nextIndices.length) return false;
+    return Math.max(...currentIndices) < Math.min(...nextIndices);
+  });
+
+  let points = 0;
+  if (correctFolderCount >= 1 && correctFolderCount <= 4) points = 2;
+  else if (correctFolderCount >= 5 && correctFolderCount <= 9) points = 4;
+  else if (correctFolderCount === 10) points = 6;
+  if (correctFolderCount === 10 && alphabeticalOrderMet) points = folderOrderMet ? 8 : 7;
+
+  const mistakes: string[] = [];
+  if (correctFolderCount < 10) mistakes.push(`${10 - correctFolderCount} Ordner nicht korrekt auf 10% verteilt`);
+  if (correctFolderCount === 10 && !alphabeticalOrderMet) mistakes.push('alphabetische Reihenfolge in mindestens einem Ordner nicht eingehalten');
+  if (correctFolderCount === 10 && alphabeticalOrderMet && !folderOrderMet) mistakes.push('Ordner-Reihenfolge untereinander nicht eingehalten');
+
+  return { points, max: 8, mistakes };
+});
+
+const q5ExpectedDays = new Set([5, 7, 10]);
+const q5DayPoints: Record<number, number> = { 5: 2, 7: 2, 10: 4 };
+const q5Score = computed(() => {
+  const selectedDays = Array.from({ length: 10 }, (_, idx) => idx + 1).filter((day) => q5StampDays.value[day] === true);
+  const points = selectedDays.reduce((total, day) => total + (q5ExpectedDays.has(day) ? q5DayPoints[day] : 0), 0);
+  const missing = [5, 7, 10].filter((day) => !selectedDays.includes(day));
+  const wrong = selectedDays.filter((day) => !q5ExpectedDays.has(day));
+  const mistakes: string[] = [];
+  if (missing.length) mistakes.push(`fehlende korrekte Tage: ${missing.join(', ')}`);
+  if (wrong.length) mistakes.push(`falsch zusätzlich markiert: ${wrong.join(', ')}`);
+  return { points, max: 8, mistakes };
+});
+
+const q6Score = computed(() => {
+  const points = toNumber(q6Scoring.value?.points) ?? 0;
+  const max = toNumber(q6Scoring.value?.max) ?? 8;
+  const explanation: string[] = [];
+
+  if (!q6Scoring.value) {
+    explanation.push('Keine automatische Detailwertung vorhanden.');
+    return { points, max, explanation };
+  }
+
+  explanation.push(`Korrekte Reihen: ${q6Scoring.value.rowCorrectCount ?? 0}`);
+  explanation.push(`Alle 6 Personen benachrichtigt: ${q6Scoring.value.allPeopleNotified ? 'ja' : 'nein'}`);
+  explanation.push(`Telefon sinnvoll eingesetzt: ${q6Scoring.value.hasPhoneUsage ? 'ja' : 'nein'}`);
+  explanation.push(`Bestzeit erreicht: ${q6Scoring.value.isBestTime ? 'ja' : 'nein'}`);
+  explanation.push(`Vergabtes Ergebnis: ${points}/${max}`);
+
+  return { points, max, explanation };
+});
+
+const totalPoints = computed(() => q1Stats.value.points + (q2ManualPoints.value ?? 0) + q3Score.value.points + q4Score.value.points + q5Score.value.points + q6Score.value.points);
+const totalTime = computed(() => formatTime(toNumber(props.results?.total_time_seconds)));
+
 function sanitizeManualPoints(event: Event) {
   const target = event.target as HTMLInputElement;
   const sanitized = target.value.replace(/\D/g, '').slice(0, 2);
-  q2ManualPoints.value = sanitized;
+  q2ManualPointsInput.value = sanitized;
   target.value = sanitized;
 }
 
 async function persistQ2ManualPoints() {
-  const value = q2ManualPoints.value === '' ? null : Number(q2ManualPoints.value);
+  const value = q2ManualPoints.value;
   emit('manual-score-updated', { key: q2ManualScoreKey, value });
   if (!props.testResultId) return;
 
@@ -64,99 +238,142 @@ async function persistQ2ManualPoints() {
 </script>
 
 <template>
-  <div class="space-y-8">
-    <section class="space-y-3">
-      <h3 class="text-lg font-semibold">BT – Aufgabe 1</h3>
-      <div class="overflow-x-auto">
-        <table class="min-w-full table-fixed rounded-lg border text-sm shadow">
-          <thead>
-            <tr>
-              <th class="w-24 border p-1 text-left">Aufgabe 1</th>
-              <th v-for="day in days" :key="day" class="border p-1 text-center">{{ day }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th class="border p-1 text-left" rowspan="2">Frühdienst</th>
-              <td v-for="day in days" :key="`e1-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('early', 1, day)] ?? '—' }}</td>
-            </tr>
-            <tr>
-              <td v-for="day in days" :key="`e2-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('early', 2, day)] ?? '—' }}</td>
-            </tr>
-            <tr>
-              <th class="border p-1 text-left" rowspan="3">Spätdienst</th>
-              <td v-for="day in days" :key="`l1-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 1, day)] ?? '—' }}</td>
-            </tr>
-            <tr>
-              <td v-for="day in days" :key="`l2-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 2, day)] ?? '—' }}</td>
-            </tr>
-            <tr>
-              <td v-for="day in days" :key="`l3-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 3, day)] ?? '—' }}</td>
-            </tr>
-          </tbody>
-        </table>
+  <div class="space-y-4">
+    <table class="mb-4 w-full overflow-hidden rounded-lg border text-sm shadow">
+      <tbody>
+        <tr class="bg-muted/40">
+          <td class="w-1/2 px-3 py-2 font-semibold">Gesamtpunkte</td>
+          <td class="px-3 py-2">{{ totalPoints }}</td>
+        </tr>
+        <tr>
+          <td class="px-3 py-2 font-semibold">Benötigte Zeit</td>
+          <td class="px-3 py-2">{{ totalTime }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <details v-if="showAnswers" class="mt-4">
+      <summary class="cursor-pointer font-medium">Antworten anzeigen</summary>
+
+      <div class="mt-4 space-y-8">
+        <section class="space-y-3">
+          <h3 class="text-lg font-semibold">BT – Aufgabe 1 ({{ q1Stats.points }}/{{ q1Stats.max }})</h3>
+          <div class="overflow-x-auto">
+            <table class="min-w-full table-fixed rounded-lg border text-sm shadow">
+              <thead>
+                <tr>
+                  <th class="w-24 border p-1 text-left">Aufgabe 1</th>
+                  <th v-for="day in days" :key="day" class="border p-1 text-center">{{ day }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th class="border p-1 text-left" rowspan="2">Frühdienst</th>
+                  <td v-for="day in days" :key="`e1-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('early', 1, day)] ?? '—' }}</td>
+                </tr>
+                <tr>
+                  <td v-for="day in days" :key="`e2-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('early', 2, day)] ?? '—' }}</td>
+                </tr>
+                <tr>
+                  <th class="border p-1 text-left" rowspan="3">Spätdienst</th>
+                  <td v-for="day in days" :key="`l1-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 1, day)] ?? '—' }}</td>
+                </tr>
+                <tr>
+                  <td v-for="day in days" :key="`l2-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 2, day)] ?? '—' }}</td>
+                </tr>
+                <tr>
+                  <td v-for="day in days" :key="`l3-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 3, day)] ?? '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="text-sm text-muted-foreground">
+            Abzüge: 2-silbig Früh {{ q1Stats.earlyTwoSyllable }}/9, 3-silbig Früh {{ q1Stats.earlyThreeSyllable }}/1,
+            1-silbig Spät {{ q1Stats.lateOneSyllable }}/8, 3-silbig Spät {{ q1Stats.lateThreeSyllable }}/7.
+          </p>
+        </section>
+
+        <section class="space-y-3">
+          <h3 class="text-lg font-semibold">BT – Aufgabe 2 ({{ q2ManualPoints ?? '—' }} P.)</h3>
+          <p class="text-sm text-muted-foreground">Punkteingabe durch Prüfer:in (manuell).</p>
+          <Input :model-value="q2ManualPointsInput" class="w-24" inputmode="numeric" @input="sanitizeManualPoints" @blur="persistQ2ManualPoints" />
+        </section>
+
+        <section class="space-y-3">
+          <h3 class="text-lg font-semibold">BT – Aufgabe 3 ({{ q3Score.points }}/{{ q3Score.max }})</h3>
+          <table class="min-w-full rounded-lg border text-sm shadow">
+            <thead>
+              <tr>
+                <th class="border p-1 text-left">Geldsorten</th>
+                <th v-for="entry in q3Denominations" :key="entry.key" class="border p-1 text-center">{{ entry.label }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th class="border p-1 text-left">Anzahl</th>
+                <td v-for="entry in q3Denominations" :key="`val-${entry.key}`" class="border p-1 text-center">{{ q3CashAnswers[entry.key] || '—' }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="text-sm text-muted-foreground">Abzüge: {{ q3Score.mistakes.length ? q3Score.mistakes.join(' | ') : 'keine' }}.</p>
+        </section>
+
+        <section class="space-y-3">
+          <h3 class="text-lg font-semibold">BT – Aufgabe 4 ({{ q4Score.points }}/{{ q4Score.max }})</h3>
+          <table class="min-w-full rounded-lg border text-sm shadow">
+            <thead><tr><th class="border p-1 text-left">Ordner-Nr.</th><th v-for="i in 10" :key="`h-${i}`" class="border p-1">{{ i }}</th></tr></thead>
+            <tbody>
+              <tr><td class="border p-1">Buchstaben</td><td v-for="i in 10" :key="`f-${i}`" class="border p-1">{{ q4FolderAnswers[i] || '—' }}</td></tr>
+            </tbody>
+          </table>
+          <p class="text-sm text-muted-foreground">Abzüge: {{ q4Score.mistakes.length ? q4Score.mistakes.join(' | ') : 'keine' }}.</p>
+        </section>
+
+        <section class="space-y-3">
+          <h3 class="text-lg font-semibold">BT – Aufgabe 5 ({{ q5Score.points }}/{{ q5Score.max }})</h3>
+          <table class="min-w-full rounded-lg border text-sm shadow">
+            <thead>
+              <tr>
+                <th class="border p-1 text-left">Arbeitstag</th>
+                <th v-for="day in 10" :key="`head-${day}`" class="border p-1 text-center">{{ day }}.AT</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th class="border p-1 text-left">Markiert</th>
+                <td v-for="day in 10" :key="`mark-${day}`" class="border p-1 text-center">{{ q5StampDays[day] ? 'X' : '—' }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="text-sm text-muted-foreground">Abzüge: {{ q5Score.mistakes.length ? q5Score.mistakes.join(' | ') : 'keine' }}.</p>
+        </section>
+
+        <section class="space-y-3">
+          <h3 class="text-lg font-semibold">BT – Aufgabe 6 ({{ q6Score.points }}/{{ q6Score.max }})</h3>
+          <table class="min-w-full rounded-lg border text-sm shadow">
+            <thead><tr><th class="border p-1">von</th><th class="border p-1">nach</th><th class="border p-1">Zeit (Weg)</th><th class="border p-1">Zeit (Nachr.)</th></tr></thead>
+            <tbody>
+              <tr v-for="row in 6" :key="row">
+                <td class="border p-1">{{ q6RouteAssignments[`route-from-${row}`] || '—' }}</td>
+                <td class="border p-1">{{ q6RouteAssignments[`route-to-${row}`] || '—' }}</td>
+                <td class="border p-1">{{ q6RouteTimes[`route-time-${row}`] || '—' }}</td>
+                <td class="border p-1">{{ q6RouteTimes[`route-msg-${row}`] || '—' }}</td>
+              </tr>
+              <tr>
+                <td class="border p-1 text-right" colspan="2">Gesamtzeit</td>
+                <td class="border p-1">{{ q6RouteTotals.totalWay || '—' }}</td>
+                <td class="border p-1">{{ q6RouteTotals.totalMsg || '—' }}</td>
+              </tr>
+              <tr>
+                <td class="border p-1 text-right" colspan="2">Rückweg</td>
+                <td class="border p-1">{{ q6RouteTotals.returnWay || '—' }}</td>
+                <td class="border p-1">—</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="text-sm text-muted-foreground">Punkte-Herleitung: {{ q6Score.explanation.join(' | ') }}</p>
+        </section>
       </div>
-    </section>
-
-    <section class="space-y-3">
-      <h3 class="text-lg font-semibold">BT – Aufgabe 2</h3>
-      <p class="text-sm text-muted-foreground">Punkteingabe durch Prüfer:in (manuell).</p>
-      <Input :model-value="q2ManualPoints" class="w-24" inputmode="numeric" @input="sanitizeManualPoints" @blur="persistQ2ManualPoints" />
-    </section>
-
-    <section class="space-y-3">
-      <h3 class="text-lg font-semibold">BT – Aufgabe 3</h3>
-      <table class="min-w-full rounded-lg border text-sm shadow">
-        <thead><tr><th class="border p-1 text-left">Geldsorte</th><th class="border p-1 text-left">Anzahl</th></tr></thead>
-        <tbody>
-          <tr v-for="(label, key) in { '100': '100€', '50': '50€', '20': '20€', '10': '10€', '5': '5€', '2': '2€', '1': '1€', '0.5': '0,50€' }" :key="key">
-            <td class="border p-1">{{ label }}</td><td class="border p-1">{{ q3CashAnswers[key] || '—' }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section class="space-y-3">
-      <h3 class="text-lg font-semibold">BT – Aufgabe 4</h3>
-      <table class="min-w-full rounded-lg border text-sm shadow">
-        <thead><tr><th class="border p-1 text-left">Ordner-Nr.</th><th v-for="i in 10" :key="`h-${i}`" class="border p-1">{{ i }}</th></tr></thead>
-        <tbody>
-          <tr><td class="border p-1">Buchstaben</td><td v-for="i in 10" :key="`f-${i}`" class="border p-1">{{ q4FolderAnswers[i] || '—' }}</td></tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section class="space-y-3">
-      <h3 class="text-lg font-semibold">BT – Aufgabe 5</h3>
-      <table class="min-w-full rounded-lg border text-sm shadow">
-        <thead><tr><th class="border p-1 text-left">Tag</th><th class="border p-1 text-left">Markiert</th></tr></thead>
-        <tbody><tr v-for="day in 10" :key="day"><td class="border p-1">{{ day }}.AT</td><td class="border p-1">{{ q5StampDays[day] ? 'X' : '—' }}</td></tr></tbody>
-      </table>
-    </section>
-
-    <section class="space-y-3">
-      <h3 class="text-lg font-semibold">BT – Aufgabe 6</h3>
-      <table class="min-w-full rounded-lg border text-sm shadow">
-        <thead><tr><th class="border p-1">von</th><th class="border p-1">nach</th><th class="border p-1">Zeit (Weg)</th><th class="border p-1">Zeit (Nachr.)</th></tr></thead>
-        <tbody>
-          <tr v-for="row in 6" :key="row">
-            <td class="border p-1">{{ q6RouteAssignments[`route-from-${row}`] || '—' }}</td>
-            <td class="border p-1">{{ q6RouteAssignments[`route-to-${row}`] || '—' }}</td>
-            <td class="border p-1">{{ q6RouteTimes[`route-time-${row}`] || '—' }}</td>
-            <td class="border p-1">{{ q6RouteTimes[`route-msg-${row}`] || '—' }}</td>
-          </tr>
-          <tr>
-            <td class="border p-1 text-right" colspan="2">Gesamtzeit</td>
-            <td class="border p-1">{{ q6RouteTotals.totalWay || '—' }}</td>
-            <td class="border p-1">{{ q6RouteTotals.totalMsg || '—' }}</td>
-          </tr>
-          <tr>
-            <td class="border p-1 text-right" colspan="2">Rückweg</td>
-            <td class="border p-1">{{ q6RouteTotals.returnWay || '—' }}</td>
-            <td class="border p-1">—</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
+    </details>
   </div>
 </template>

--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -9,11 +9,13 @@ const props = withDefaults(
     manualScores?: Record<string, number | string | null>;
     results?: Record<string, any> | null;
     showAnswers?: boolean;
+    forceOpenAnswers?: boolean;
   }>(),
   {
     manualScores: () => ({}),
     results: null,
     showAnswers: true,
+    forceOpenAnswers: false,
   },
 );
 
@@ -252,7 +254,7 @@ async function persistQ2ManualPoints() {
       </tbody>
     </table>
 
-    <details v-if="showAnswers" class="mt-4">
+    <details v-if="showAnswers" class="mt-4 rounded-lg border bg-background p-3" :open="forceOpenAnswers">
       <summary class="cursor-pointer font-medium">Antworten anzeigen</summary>
 
       <div class="mt-4 space-y-8">

--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -240,12 +240,12 @@ async function persistQ2ManualPoints() {
 </script>
 
 <template>
-  <div class="space-y-3">
+  <div class="space-y-3 w-full lg:w-1/2 print:w-full">
     <div class="rounded-lg border-2 border-black bg-white p-3 text-sm">
       <div class="mb-3 flex items-center justify-between border-b border-black pb-2">
         <div class="font-semibold">BT – Auswertung Form A</div>
         <div class="text-right">
-          <div><span class="font-semibold">Gesamtpunkte:</span> {{ totalPoints }} / 50</div>
+          <div class="text-lg"><span class="font-semibold">Rohwert:</span> <span class="text-2xl font-bold">{{ totalPoints }}</span> <span class="font-semibold">/ 50</span></div>
           <div><span class="font-semibold">Benötigte Zeit:</span> {{ totalTime }}</div>
         </div>
       </div>
@@ -380,8 +380,8 @@ async function persistQ2ManualPoints() {
           </tr>
 
           <tr>
-            <td class="border border-black p-2 text-right font-bold">Gesamt</td>
-            <td class="border border-black p-2 text-center font-bold">{{ totalPoints }}</td>
+            <td class="border border-black p-2 text-right text-lg font-bold">Rohwert</td>
+            <td class="border border-black p-2 text-center text-xl font-extrabold">{{ totalPoints }}</td>
           </tr>
         </tbody>
       </table>

--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -240,142 +240,151 @@ async function persistQ2ManualPoints() {
 </script>
 
 <template>
-  <div class="space-y-4">
-    <table class="mb-4 w-full overflow-hidden rounded-lg border text-sm shadow">
-      <tbody>
-        <tr class="bg-muted/40">
-          <td class="w-1/2 px-3 py-2 font-semibold">Gesamtpunkte</td>
-          <td class="px-3 py-2">{{ totalPoints }}</td>
-        </tr>
-        <tr>
-          <td class="px-3 py-2 font-semibold">Benötigte Zeit</td>
-          <td class="px-3 py-2">{{ totalTime }}</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <details v-if="showAnswers" class="mt-4 rounded-lg border bg-background p-3" :open="forceOpenAnswers">
-      <summary class="cursor-pointer font-medium">Antworten anzeigen</summary>
-
-      <div class="mt-4 space-y-8">
-        <section class="space-y-3">
-          <h3 class="text-lg font-semibold">BT – Aufgabe 1 ({{ q1Stats.points }}/{{ q1Stats.max }})</h3>
-          <div class="overflow-x-auto">
-            <table class="min-w-full table-fixed rounded-lg border text-sm shadow">
-              <thead>
-                <tr>
-                  <th class="w-24 border p-1 text-left">Aufgabe 1</th>
-                  <th v-for="day in days" :key="day" class="border p-1 text-center">{{ day }}</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th class="border p-1 text-left" rowspan="2">Frühdienst</th>
-                  <td v-for="day in days" :key="`e1-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('early', 1, day)] ?? '—' }}</td>
-                </tr>
-                <tr>
-                  <td v-for="day in days" :key="`e2-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('early', 2, day)] ?? '—' }}</td>
-                </tr>
-                <tr>
-                  <th class="border p-1 text-left" rowspan="3">Spätdienst</th>
-                  <td v-for="day in days" :key="`l1-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 1, day)] ?? '—' }}</td>
-                </tr>
-                <tr>
-                  <td v-for="day in days" :key="`l2-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 2, day)] ?? '—' }}</td>
-                </tr>
-                <tr>
-                  <td v-for="day in days" :key="`l3-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 3, day)] ?? '—' }}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <p class="text-sm text-muted-foreground">
-            Abzüge: 2-silbig Früh {{ q1Stats.earlyTwoSyllable }}/9, 3-silbig Früh {{ q1Stats.earlyThreeSyllable }}/1,
-            1-silbig Spät {{ q1Stats.lateOneSyllable }}/8, 3-silbig Spät {{ q1Stats.lateThreeSyllable }}/7.
-          </p>
-        </section>
-
-        <section class="space-y-3">
-          <h3 class="text-lg font-semibold">BT – Aufgabe 2 ({{ q2ManualPoints ?? '—' }} P.)</h3>
-          <p class="text-sm text-muted-foreground">Punkteingabe durch Prüfer:in (manuell).</p>
-          <Input :model-value="q2ManualPointsInput" class="w-24" inputmode="numeric" @input="sanitizeManualPoints" @blur="persistQ2ManualPoints" />
-        </section>
-
-        <section class="space-y-3">
-          <h3 class="text-lg font-semibold">BT – Aufgabe 3 ({{ q3Score.points }}/{{ q3Score.max }})</h3>
-          <table class="min-w-full rounded-lg border text-sm shadow">
-            <thead>
-              <tr>
-                <th class="border p-1 text-left">Geldsorten</th>
-                <th v-for="entry in q3Denominations" :key="entry.key" class="border p-1 text-center">{{ entry.label }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th class="border p-1 text-left">Anzahl</th>
-                <td v-for="entry in q3Denominations" :key="`val-${entry.key}`" class="border p-1 text-center">{{ q3CashAnswers[entry.key] || '—' }}</td>
-              </tr>
-            </tbody>
-          </table>
-          <p class="text-sm text-muted-foreground">Abzüge: {{ q3Score.mistakes.length ? q3Score.mistakes.join(' | ') : 'keine' }}.</p>
-        </section>
-
-        <section class="space-y-3">
-          <h3 class="text-lg font-semibold">BT – Aufgabe 4 ({{ q4Score.points }}/{{ q4Score.max }})</h3>
-          <table class="min-w-full rounded-lg border text-sm shadow">
-            <thead><tr><th class="border p-1 text-left">Ordner-Nr.</th><th v-for="i in 10" :key="`h-${i}`" class="border p-1">{{ i }}</th></tr></thead>
-            <tbody>
-              <tr><td class="border p-1">Buchstaben</td><td v-for="i in 10" :key="`f-${i}`" class="border p-1">{{ q4FolderAnswers[i] || '—' }}</td></tr>
-            </tbody>
-          </table>
-          <p class="text-sm text-muted-foreground">Abzüge: {{ q4Score.mistakes.length ? q4Score.mistakes.join(' | ') : 'keine' }}.</p>
-        </section>
-
-        <section class="space-y-3">
-          <h3 class="text-lg font-semibold">BT – Aufgabe 5 ({{ q5Score.points }}/{{ q5Score.max }})</h3>
-          <table class="min-w-full rounded-lg border text-sm shadow">
-            <thead>
-              <tr>
-                <th class="border p-1 text-left">Arbeitstag</th>
-                <th v-for="day in 10" :key="`head-${day}`" class="border p-1 text-center">{{ day }}.AT</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th class="border p-1 text-left">Markiert</th>
-                <td v-for="day in 10" :key="`mark-${day}`" class="border p-1 text-center">{{ q5StampDays[day] ? 'X' : '—' }}</td>
-              </tr>
-            </tbody>
-          </table>
-          <p class="text-sm text-muted-foreground">Abzüge: {{ q5Score.mistakes.length ? q5Score.mistakes.join(' | ') : 'keine' }}.</p>
-        </section>
-
-        <section class="space-y-3">
-          <h3 class="text-lg font-semibold">BT – Aufgabe 6 ({{ q6Score.points }}/{{ q6Score.max }})</h3>
-          <table class="min-w-full rounded-lg border text-sm shadow">
-            <thead><tr><th class="border p-1">von</th><th class="border p-1">nach</th><th class="border p-1">Zeit (Weg)</th><th class="border p-1">Zeit (Nachr.)</th></tr></thead>
-            <tbody>
-              <tr v-for="row in 6" :key="row">
-                <td class="border p-1">{{ q6RouteAssignments[`route-from-${row}`] || '—' }}</td>
-                <td class="border p-1">{{ q6RouteAssignments[`route-to-${row}`] || '—' }}</td>
-                <td class="border p-1">{{ q6RouteTimes[`route-time-${row}`] || '—' }}</td>
-                <td class="border p-1">{{ q6RouteTimes[`route-msg-${row}`] || '—' }}</td>
-              </tr>
-              <tr>
-                <td class="border p-1 text-right" colspan="2">Gesamtzeit</td>
-                <td class="border p-1">{{ q6RouteTotals.totalWay || '—' }}</td>
-                <td class="border p-1">{{ q6RouteTotals.totalMsg || '—' }}</td>
-              </tr>
-              <tr>
-                <td class="border p-1 text-right" colspan="2">Rückweg</td>
-                <td class="border p-1">{{ q6RouteTotals.returnWay || '—' }}</td>
-                <td class="border p-1">—</td>
-              </tr>
-            </tbody>
-          </table>
-          <p class="text-sm text-muted-foreground">Punkte-Herleitung: {{ q6Score.explanation.join(' | ') }}</p>
-        </section>
+  <div class="space-y-3">
+    <div class="rounded-lg border-2 border-black bg-white p-3 text-sm">
+      <div class="mb-3 flex items-center justify-between border-b border-black pb-2">
+        <div class="font-semibold">BT – Auswertung Form A</div>
+        <div class="text-right">
+          <div><span class="font-semibold">Gesamtpunkte:</span> {{ totalPoints }} / 50</div>
+          <div><span class="font-semibold">Benötigte Zeit:</span> {{ totalTime }}</div>
+        </div>
       </div>
-    </details>
+
+      <table class="w-full border-collapse border border-black">
+        <thead>
+          <tr>
+            <th class="border border-black p-2 text-left">Aufgabe</th>
+            <th class="w-20 border border-black p-2 text-center">Punkte</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="border border-black p-2 align-top">
+              <div class="mb-2 font-semibold">Aufgabe 1</div>
+              <div>Frühdienst: zweisilbig {{ q1Stats.earlyTwoSyllable }}/9, dreisilbig {{ q1Stats.earlyThreeSyllable }}/1</div>
+              <div>Spätdienst: einsilbig {{ q1Stats.lateOneSyllable }}/8, dreisilbig {{ q1Stats.lateThreeSyllable }}/7</div>
+              <div class="mt-1 text-muted-foreground">Abzüge gemäß Soll-Verteilung.</div>
+            </td>
+            <td class="border border-black p-2 text-center font-semibold">{{ q1Stats.points }}</td>
+          </tr>
+
+          <tr>
+            <td class="border border-black p-2 align-top">
+              <div class="mb-2 font-semibold">Aufgabe 2</div>
+              <div class="mb-2">Manuelle Bewertung durch Prüfer:in (ein Feld).</div>
+              <Input :model-value="q2ManualPointsInput" class="w-24" inputmode="numeric" @input="sanitizeManualPoints" @blur="persistQ2ManualPoints" />
+            </td>
+            <td class="border border-black p-2 text-center font-semibold">{{ q2ManualPoints ?? '—' }}</td>
+          </tr>
+
+          <tr>
+            <td class="border border-black p-2 align-top">
+              <div class="mb-2 font-semibold">Aufgabe 3</div>
+              <table class="w-full border-collapse border border-black text-xs">
+                <thead>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Geldsorten</th>
+                    <th v-for="entry in q3Denominations" :key="entry.key" class="border border-black p-1 text-center">{{ entry.label }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Anzahl</th>
+                    <td v-for="entry in q3Denominations" :key="`q3-${entry.key}`" class="border border-black p-1 text-center">{{ q3CashAnswers[entry.key] || '—' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="mt-1 text-muted-foreground">Abzüge: {{ q3Score.mistakes.length ? q3Score.mistakes.join(' | ') : 'keine' }}.</div>
+            </td>
+            <td class="border border-black p-2 text-center font-semibold">{{ q3Score.points }}</td>
+          </tr>
+
+          <tr>
+            <td class="border border-black p-2 align-top">
+              <div class="mb-2 font-semibold">Aufgabe 4</div>
+              <table class="w-full border-collapse border border-black text-xs">
+                <thead>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Ordner-Nr.</th>
+                    <th v-for="i in 10" :key="`h-${i}`" class="border border-black p-1 text-center">{{ i }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Form A</th>
+                    <td v-for="i in 10" :key="`f-${i}`" class="border border-black p-1 text-center">{{ q4FolderAnswers[i] || '—' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="mt-1 text-muted-foreground">Abzüge: {{ q4Score.mistakes.length ? q4Score.mistakes.join(' | ') : 'keine' }}.</div>
+            </td>
+            <td class="border border-black p-2 text-center font-semibold">{{ q4Score.points }}</td>
+          </tr>
+
+          <tr>
+            <td class="border border-black p-2 align-top">
+              <div class="mb-2 font-semibold">Aufgabe 5</div>
+              <table class="w-full border-collapse border border-black text-xs">
+                <thead>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Neue Briefmarken gekauft am</th>
+                    <th v-for="day in 10" :key="`d-${day}`" class="border border-black p-1 text-center">{{ day }}.</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Form A</th>
+                    <td v-for="day in 10" :key="`m-${day}`" class="border border-black p-1 text-center">{{ q5StampDays[day] ? 'X' : '' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="mt-1 text-muted-foreground">Abzüge: {{ q5Score.mistakes.length ? q5Score.mistakes.join(' | ') : 'keine' }}.</div>
+            </td>
+            <td class="border border-black p-2 text-center font-semibold">{{ q5Score.points }}</td>
+          </tr>
+
+          <tr>
+            <td class="border border-black p-2 align-top">
+              <div class="mb-2 font-semibold">Aufgabe 6</div>
+              <table class="w-full border-collapse border border-black text-xs">
+                <thead>
+                  <tr>
+                    <th class="border border-black p-1 text-left">von</th>
+                    <th class="border border-black p-1 text-left">nach</th>
+                    <th class="border border-black p-1 text-center">Zeit (Weg)</th>
+                    <th class="border border-black p-1 text-center">Zeit (Nachr.)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="row in 6" :key="`r-${row}`">
+                    <td class="border border-black p-1">{{ q6RouteAssignments[`route-from-${row}`] || '—' }}</td>
+                    <td class="border border-black p-1">{{ q6RouteAssignments[`route-to-${row}`] || '—' }}</td>
+                    <td class="border border-black p-1 text-center">{{ q6RouteTimes[`route-time-${row}`] || '—' }}</td>
+                    <td class="border border-black p-1 text-center">{{ q6RouteTimes[`route-msg-${row}`] || '—' }}</td>
+                  </tr>
+                  <tr>
+                    <td class="border border-black p-1 text-right" colspan="2">Gesamtzeit</td>
+                    <td class="border border-black p-1 text-center">{{ q6RouteTotals.totalWay || '—' }}</td>
+                    <td class="border border-black p-1 text-center">{{ q6RouteTotals.totalMsg || '—' }}</td>
+                  </tr>
+                  <tr>
+                    <td class="border border-black p-1 text-right" colspan="2">anschl. zurück z. eig. Wohnung</td>
+                    <td class="border border-black p-1 text-center">{{ q6RouteTotals.returnWay || '—' }}</td>
+                    <td class="border border-black p-1 text-center">—</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="mt-1 text-muted-foreground">Punkte-Herleitung: {{ q6Score.explanation.join(' | ') }}</div>
+            </td>
+            <td class="border border-black p-2 text-center font-semibold">{{ q6Score.points }}</td>
+          </tr>
+
+          <tr>
+            <td class="border border-black p-2 text-right font-bold">Gesamt</td>
+            <td class="border border-black p-2 text-center font-bold">{{ totalPoints }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>

--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -240,7 +240,7 @@ async function persistQ2ManualPoints() {
 </script>
 
 <template>
-  <div class="space-y-3 w-full lg:w-1/2 print:w-full">
+  <div :class="['space-y-3 w-full', !forceOpenAnswers ? 'lg:w-1/2' : '']">
     <div class="rounded-lg border-2 border-black bg-white p-3 text-sm">
       <div class="mb-3 flex items-center justify-between border-b border-black pb-2">
         <div class="font-semibold">BT – Auswertung Form A</div>
@@ -261,6 +261,36 @@ async function persistQ2ManualPoints() {
           <tr>
             <td class="border border-black p-2 align-top">
               <div class="mb-2 font-semibold">Aufgabe 1</div>
+              <table class="mb-2 w-full border-collapse border border-black text-xs">
+                <thead>
+                  <tr>
+                    <th class="w-20 border border-black p-1 text-left">Dienst</th>
+                    <th v-for="day in days" :key="`q1-head-${day}`" class="border border-black p-1 text-center">{{ day }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Früh 1</th>
+                    <td v-for="day in days" :key="`q1-e1-${day}`" class="border border-black p-1 text-center">{{ q1Assignments[buildCellKey('early', 1, day)] ?? '—' }}</td>
+                  </tr>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Früh 2</th>
+                    <td v-for="day in days" :key="`q1-e2-${day}`" class="border border-black p-1 text-center">{{ q1Assignments[buildCellKey('early', 2, day)] ?? '—' }}</td>
+                  </tr>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Spät 1</th>
+                    <td v-for="day in days" :key="`q1-l1-${day}`" class="border border-black p-1 text-center">{{ q1Assignments[buildCellKey('late', 1, day)] ?? '—' }}</td>
+                  </tr>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Spät 2</th>
+                    <td v-for="day in days" :key="`q1-l2-${day}`" class="border border-black p-1 text-center">{{ q1Assignments[buildCellKey('late', 2, day)] ?? '—' }}</td>
+                  </tr>
+                  <tr>
+                    <th class="border border-black p-1 text-left">Spät 3</th>
+                    <td v-for="day in days" :key="`q1-l3-${day}`" class="border border-black p-1 text-center">{{ q1Assignments[buildCellKey('late', 3, day)] ?? '—' }}</td>
+                  </tr>
+                </tbody>
+              </table>
               <div>Frühdienst: zweisilbig {{ q1Stats.earlyTwoSyllable }}/9, dreisilbig {{ q1Stats.earlyThreeSyllable }}/1</div>
               <div>Spätdienst: einsilbig {{ q1Stats.lateOneSyllable }}/8, dreisilbig {{ q1Stats.lateThreeSyllable }}/7</div>
               <div class="mt-1 text-muted-foreground">Abzüge gemäß Soll-Verteilung.</div>

--- a/resources/js/components/BtResult.vue
+++ b/resources/js/components/BtResult.vue
@@ -4,444 +4,159 @@ import axios from 'axios';
 import { computed, ref, watch } from 'vue';
 
 const props = withDefaults(
-    defineProps<{
-        testResultId?: number | null;
-        manualScores?: Record<string, number | string | null>;
-    }>(),
-    {
-        manualScores: () => ({}),
-    },
+  defineProps<{
+    testResultId?: number | null;
+    manualScores?: Record<string, number | string | null>;
+    results?: Record<string, any> | null;
+  }>(),
+  {
+    manualScores: () => ({}),
+    results: null,
+  },
 );
 
 const emit = defineEmits<{
-    'manual-score-updated': [{ key: string; value: number | null }];
+  'manual-score-updated': [{ key: string; value: number | null }];
 }>();
 
-const scoreKeys = {
-    earlyTwoSyllableCount: 'bt_q1_early_two_syllable_count',
-    earlyThreeSyllableCount: 'bt_q1_early_three_syllable_count',
-    lateOneSyllableCount: 'bt_q1_late_one_syllable_count',
-    lateThreeSyllableCount: 'bt_q1_late_three_syllable_count',
-    q3Count100: 'bt_q3_count_100',
-    q3Count50: 'bt_q3_count_50',
-    q3Count20: 'bt_q3_count_20',
-    q3Count10: 'bt_q3_count_10',
-    q3Count5: 'bt_q3_count_5',
-    q3Count2: 'bt_q3_count_2',
-    q3Count1: 'bt_q3_count_1',
-    q3Count050: 'bt_q3_count_050',
-    q4CorrectFolderCount: 'bt_q4_correct_folder_count',
-    q4AlphabeticalOrderMet: 'bt_q4_alphabetical_order_met',
-    q4FolderOrderMet: 'bt_q4_folder_order_met',
-    q5Day1Selected: 'bt_q5_day_1_selected',
-    q5Day2Selected: 'bt_q5_day_2_selected',
-    q5Day3Selected: 'bt_q5_day_3_selected',
-    q5Day4Selected: 'bt_q5_day_4_selected',
-    q5Day5Selected: 'bt_q5_day_5_selected',
-    q5Day6Selected: 'bt_q5_day_6_selected',
-    q5Day7Selected: 'bt_q5_day_7_selected',
-    q5Day8Selected: 'bt_q5_day_8_selected',
-    q5Day9Selected: 'bt_q5_day_9_selected',
-    q5Day10Selected: 'bt_q5_day_10_selected',
-} as const;
-const q5CorrectDays = new Set([5, 7, 10]);
-const q5DayPoints: Record<number, number> = {
-    5: 2,
-    7: 2,
-    10: 4,
-};
-const q5DayEntries = [
-    { day: 1, key: scoreKeys.q5Day1Selected },
-    { day: 2, key: scoreKeys.q5Day2Selected },
-    { day: 3, key: scoreKeys.q5Day3Selected },
-    { day: 4, key: scoreKeys.q5Day4Selected },
-    { day: 5, key: scoreKeys.q5Day5Selected },
-    { day: 6, key: scoreKeys.q5Day6Selected },
-    { day: 7, key: scoreKeys.q5Day7Selected },
-    { day: 8, key: scoreKeys.q5Day8Selected },
-    { day: 9, key: scoreKeys.q5Day9Selected },
-    { day: 10, key: scoreKeys.q5Day10Selected },
-] as const;
+const q2ManualScoreKey = 'bt_q2_manual_points';
+const q2ManualPoints = ref('');
+const days = ['Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag'];
 
-const questionThreeCriteria = [
-    { label: '100,-', key: scoreKeys.q3Count100, expected: 64 },
-    { label: '50,-', key: scoreKeys.q3Count50, expected: 3 },
-    { label: '20,-', key: scoreKeys.q3Count20, expected: 6 },
-    { label: '10,-', key: scoreKeys.q3Count10, expected: 3 },
-    { label: '5,-', key: scoreKeys.q3Count5, expected: 3 },
-    { label: '2,-', key: scoreKeys.q3Count2, expected: 4 },
-    { label: '1,-', key: scoreKeys.q3Count1, expected: 5 },
-    { label: '0,50', key: scoreKeys.q3Count050, expected: 4 },
-] as const;
-
-const values = ref<Record<string, string>>({
-    [scoreKeys.earlyTwoSyllableCount]: '',
-    [scoreKeys.earlyThreeSyllableCount]: '',
-    [scoreKeys.lateOneSyllableCount]: '',
-    [scoreKeys.lateThreeSyllableCount]: '',
-    [scoreKeys.q3Count100]: '',
-    [scoreKeys.q3Count50]: '',
-    [scoreKeys.q3Count20]: '',
-    [scoreKeys.q3Count10]: '',
-    [scoreKeys.q3Count5]: '',
-    [scoreKeys.q3Count2]: '',
-    [scoreKeys.q3Count1]: '',
-    [scoreKeys.q3Count050]: '',
-    [scoreKeys.q4CorrectFolderCount]: '',
-});
-const q4AlphabeticalOrderMet = ref(false);
-const q4FolderOrderMet = ref(false);
-const q5SelectedDays = ref<Record<number, boolean>>(Object.fromEntries(q5DayEntries.map((entry) => [entry.day, false])));
+const q1Assignments = computed<Record<string, string | null>>(() => props.results?.assignments ?? {});
+const q3CashAnswers = computed<Record<string, string>>(() => props.results?.cash_answers ?? {});
+const q4FolderAnswers = computed<Record<number, string>>(() => props.results?.folder_answers ?? {});
+const q5StampDays = computed<Record<number, boolean>>(() => props.results?.stamp_answer_days ?? {});
+const q6RouteAssignments = computed<Record<string, string | null>>(() => props.results?.route_assignments ?? {});
+const q6RouteTimes = computed<Record<string, string>>(() => props.results?.route_times ?? {});
+const q6RouteTotals = computed<Record<string, string>>(() => props.results?.route_totals ?? {});
 
 watch(
-    () => props.manualScores,
-    (next) => {
-        values.value[scoreKeys.earlyTwoSyllableCount] = toInput(next?.[scoreKeys.earlyTwoSyllableCount]);
-        values.value[scoreKeys.earlyThreeSyllableCount] = toInput(next?.[scoreKeys.earlyThreeSyllableCount]);
-        values.value[scoreKeys.lateOneSyllableCount] = toInput(next?.[scoreKeys.lateOneSyllableCount]);
-        values.value[scoreKeys.lateThreeSyllableCount] = toInput(next?.[scoreKeys.lateThreeSyllableCount]);
-        values.value[scoreKeys.q3Count100] = toInput(next?.[scoreKeys.q3Count100]);
-        values.value[scoreKeys.q3Count50] = toInput(next?.[scoreKeys.q3Count50]);
-        values.value[scoreKeys.q3Count20] = toInput(next?.[scoreKeys.q3Count20]);
-        values.value[scoreKeys.q3Count10] = toInput(next?.[scoreKeys.q3Count10]);
-        values.value[scoreKeys.q3Count5] = toInput(next?.[scoreKeys.q3Count5]);
-        values.value[scoreKeys.q3Count2] = toInput(next?.[scoreKeys.q3Count2]);
-        values.value[scoreKeys.q3Count1] = toInput(next?.[scoreKeys.q3Count1]);
-        values.value[scoreKeys.q3Count050] = toInput(next?.[scoreKeys.q3Count050]);
-        values.value[scoreKeys.q4CorrectFolderCount] = toInput(next?.[scoreKeys.q4CorrectFolderCount]);
-        q4AlphabeticalOrderMet.value = toBoolean(next?.[scoreKeys.q4AlphabeticalOrderMet]);
-        q4FolderOrderMet.value = toBoolean(next?.[scoreKeys.q4FolderOrderMet]);
-        q5DayEntries.forEach((entry) => {
-            q5SelectedDays.value[entry.day] = toBoolean(next?.[entry.key]);
-        });
-    },
-    { immediate: true, deep: true },
+  () => props.manualScores,
+  (next) => {
+    const raw = next?.[q2ManualScoreKey];
+    q2ManualPoints.value = raw == null || raw === '' ? '' : `${raw}`;
+  },
+  { immediate: true, deep: true },
 );
 
-const earlyTwoSyllablePoints = computed(() => (toNumber(values.value[scoreKeys.earlyTwoSyllableCount]) === 9 ? 3 : 0));
-const earlyThreeSyllablePoints = computed(() => (toNumber(values.value[scoreKeys.earlyThreeSyllableCount]) === 1 ? 1 : 0));
-const lateOneSyllablePoints = computed(() => (toNumber(values.value[scoreKeys.lateOneSyllableCount]) === 8 ? 3 : 0));
-const lateThreeSyllablePoints = computed(() => (toNumber(values.value[scoreKeys.lateThreeSyllableCount]) === 7 ? 2 : 0));
-
-const questionOneTotal = computed(
-    () => earlyTwoSyllablePoints.value + earlyThreeSyllablePoints.value + lateOneSyllablePoints.value + lateThreeSyllablePoints.value,
-);
-
-const questionThreeTotal = computed(() =>
-    questionThreeCriteria.reduce((sum, criterion) => {
-        const value = toNumber(values.value[criterion.key]);
-        return sum + (value === criterion.expected ? 1 : 0);
-    }, 0),
-);
-const questionFourBasePoints = computed(() => {
-    const correctFolders = toClampedFolderCount(values.value[scoreKeys.q4CorrectFolderCount]);
-    if (correctFolders == null || correctFolders < 1) return 0;
-    if (correctFolders <= 4) return 2;
-    if (correctFolders <= 9) return 4;
-    if (correctFolders === 10) return 6;
-    return 0;
-});
-const questionFourAlphabeticalPoints = computed(() => (questionFourBasePoints.value === 6 && q4AlphabeticalOrderMet.value ? 1 : 0));
-const questionFourFolderOrderPoints = computed(() =>
-    questionFourBasePoints.value === 6 && q4AlphabeticalOrderMet.value && q4FolderOrderMet.value ? 1 : 0,
-);
-const questionFourTotal = computed(() => {
-    return questionFourBasePoints.value + questionFourAlphabeticalPoints.value + questionFourFolderOrderPoints.value;
-});
-const questionFiveTotal = computed(() =>
-    q5DayEntries.reduce((total, entry) => {
-        if (!q5SelectedDays.value[entry.day] || !q5CorrectDays.has(entry.day)) return total;
-        return total + (q5DayPoints[entry.day] ?? 0);
-    }, 0),
-);
-
-function toInput(value: number | string | null | undefined) {
-    if (value == null || value === '') return '';
-    return `${value}`;
+function buildCellKey(shift: 'early' | 'late', slot: number, day: string) {
+  return `${shift}-${slot}-${day}`;
 }
 
-function toNumber(value: string): number | null {
-    if (!value) return null;
-    const parsed = Number(value);
-    return Number.isNaN(parsed) ? null : parsed;
+function sanitizeManualPoints(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const sanitized = target.value.replace(/\D/g, '').slice(0, 2);
+  q2ManualPoints.value = sanitized;
+  target.value = sanitized;
 }
 
-function toBoolean(value: unknown): boolean {
-    if (value === true || value === 1 || value === '1' || value === 'true') return true;
-    return false;
-}
+async function persistQ2ManualPoints() {
+  const value = q2ManualPoints.value === '' ? null : Number(q2ManualPoints.value);
+  emit('manual-score-updated', { key: q2ManualScoreKey, value });
+  if (!props.testResultId) return;
 
-function toClampedFolderCount(value: string): number | null {
-    const parsed = toNumber(value);
-    if (parsed == null) return null;
-    return Math.max(0, Math.min(10, parsed));
-}
-
-function sanitizeAndSet(key: string, event: Event) {
-    const target = event.target as HTMLInputElement;
-    const sanitized = target.value.replace(/\D/g, '').slice(0, 2);
-    if (key === scoreKeys.q4CorrectFolderCount) {
-        const numeric = sanitized === '' ? '' : `${Math.min(10, Number(sanitized))}`;
-        values.value[key] = numeric;
-        target.value = numeric;
-        return;
-    }
-    values.value[key] = sanitized;
-    target.value = sanitized;
-}
-
-async function persistValue(key: string) {
-    const numericValue = toNumber(values.value[key]);
-    emit('manual-score-updated', { key, value: numericValue });
-
-    if (!props.testResultId) return;
-
-    await axios.put(route('test-results.manual-scores.update', { testResult: props.testResultId }), {
-        key,
-        value: numericValue,
-    });
-}
-
-async function persistBooleanValue(key: string, value: boolean) {
-    const numericValue = value ? 1 : 0;
-    emit('manual-score-updated', { key, value: numericValue });
-
-    if (!props.testResultId) return;
-
-    await axios.put(route('test-results.manual-scores.update', { testResult: props.testResultId }), {
-        key,
-        value: numericValue,
-    });
-}
-
-function q5StorageKeyForDay(day: number) {
-    return q5DayEntries.find((entry) => entry.day === day)?.key ?? null;
-}
-
-async function persistQ5DayValue(day: number) {
-    const key = q5StorageKeyForDay(day);
-    if (!key) return;
-    await persistBooleanValue(key, q5SelectedDays.value[day] === true);
+  await axios.put(route('test-results.manual-scores.update', { testResult: props.testResultId }), {
+    key: q2ManualScoreKey,
+    value,
+  });
 }
 </script>
 
 <template>
-    <div class="space-y-4">
-        <h3 class="text-lg font-semibold">BT – Aufgabe 1 (Scoring)</h3>
-        <p class="text-sm text-muted-foreground">
-            Punktvergabe: Frühdienst (9 zweisilbige Namen = 3 P.; 1 dreisilbiger Name = 1 P.), Spätdienst (8 einsilbige Namen = 3 P.; 7 dreisilbige
-            Namen = 2 P.)
-        </p>
+  <div class="space-y-8">
+    <section class="space-y-3">
+      <h3 class="text-lg font-semibold">BT – Aufgabe 1</h3>
+      <div class="overflow-x-auto">
+        <table class="min-w-full table-fixed rounded-lg border text-sm shadow">
+          <thead>
+            <tr>
+              <th class="w-24 border p-1 text-left">Aufgabe 1</th>
+              <th v-for="day in days" :key="day" class="border p-1 text-center">{{ day }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th class="border p-1 text-left" rowspan="2">Frühdienst</th>
+              <td v-for="day in days" :key="`e1-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('early', 1, day)] ?? '—' }}</td>
+            </tr>
+            <tr>
+              <td v-for="day in days" :key="`e2-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('early', 2, day)] ?? '—' }}</td>
+            </tr>
+            <tr>
+              <th class="border p-1 text-left" rowspan="3">Spätdienst</th>
+              <td v-for="day in days" :key="`l1-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 1, day)] ?? '—' }}</td>
+            </tr>
+            <tr>
+              <td v-for="day in days" :key="`l2-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 2, day)] ?? '—' }}</td>
+            </tr>
+            <tr>
+              <td v-for="day in days" :key="`l3-${day}`" class="border p-1">{{ q1Assignments[buildCellKey('late', 3, day)] ?? '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-        <div class="overflow-x-auto">
-            <table class="min-w-full rounded-lg border text-sm shadow">
-                <thead class="bg-muted/40">
-                    <tr>
-                        <th class="px-3 py-2 text-left">Kriterium</th>
-                        <th class="px-3 py-2 text-left">Eingabe</th>
-                        <th class="px-3 py-2 text-left">Punkte</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="px-3 py-2">Frühdienst: zweisilbige Namen (Soll: 9)</td>
-                        <td class="px-3 py-2">
-                            <Input
-                                :model-value="values[scoreKeys.earlyTwoSyllableCount]"
-                                class="w-20"
-                                inputmode="numeric"
-                                @input="(event) => sanitizeAndSet(scoreKeys.earlyTwoSyllableCount, event)"
-                                @blur="persistValue(scoreKeys.earlyTwoSyllableCount)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">{{ earlyTwoSyllablePoints }} / 3</td>
-                    </tr>
-                    <tr>
-                        <td class="px-3 py-2">Frühdienst: dreisilbige Namen (Soll: 1)</td>
-                        <td class="px-3 py-2">
-                            <Input
-                                :model-value="values[scoreKeys.earlyThreeSyllableCount]"
-                                class="w-20"
-                                inputmode="numeric"
-                                @input="(event) => sanitizeAndSet(scoreKeys.earlyThreeSyllableCount, event)"
-                                @blur="persistValue(scoreKeys.earlyThreeSyllableCount)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">{{ earlyThreeSyllablePoints }} / 1</td>
-                    </tr>
-                    <tr>
-                        <td class="px-3 py-2">Spätdienst: einsilbige Namen (Soll: 8)</td>
-                        <td class="px-3 py-2">
-                            <Input
-                                :model-value="values[scoreKeys.lateOneSyllableCount]"
-                                class="w-20"
-                                inputmode="numeric"
-                                @input="(event) => sanitizeAndSet(scoreKeys.lateOneSyllableCount, event)"
-                                @blur="persistValue(scoreKeys.lateOneSyllableCount)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">{{ lateOneSyllablePoints }} / 3</td>
-                    </tr>
-                    <tr>
-                        <td class="px-3 py-2">Spätdienst: dreisilbige Namen (Soll: 7)</td>
-                        <td class="px-3 py-2">
-                            <Input
-                                :model-value="values[scoreKeys.lateThreeSyllableCount]"
-                                class="w-20"
-                                inputmode="numeric"
-                                @input="(event) => sanitizeAndSet(scoreKeys.lateThreeSyllableCount, event)"
-                                @blur="persistValue(scoreKeys.lateThreeSyllableCount)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">{{ lateThreeSyllablePoints }} / 2</td>
-                    </tr>
-                </tbody>
-                <tfoot>
-                    <tr class="bg-muted/30">
-                        <td class="px-3 py-2 font-semibold" colspan="2">Aufgabe 1 Gesamt</td>
-                        <td class="px-3 py-2 font-bold">{{ questionOneTotal }} / 9</td>
-                    </tr>
-                </tfoot>
-            </table>
-        </div>
+    <section class="space-y-3">
+      <h3 class="text-lg font-semibold">BT – Aufgabe 2</h3>
+      <p class="text-sm text-muted-foreground">Punkteingabe durch Prüfer:in (manuell).</p>
+      <Input :model-value="q2ManualPoints" class="w-24" inputmode="numeric" @input="sanitizeManualPoints" @blur="persistQ2ManualPoints" />
+    </section>
 
-        <h3 class="text-lg font-semibold">BT – Aufgabe 3 (Scoring)</h3>
-        <p class="text-sm text-muted-foreground">Punktvergabe: Jede richtige Angabe = 1 Punkt.</p>
+    <section class="space-y-3">
+      <h3 class="text-lg font-semibold">BT – Aufgabe 3</h3>
+      <table class="min-w-full rounded-lg border text-sm shadow">
+        <thead><tr><th class="border p-1 text-left">Geldsorte</th><th class="border p-1 text-left">Anzahl</th></tr></thead>
+        <tbody>
+          <tr v-for="(label, key) in { '100': '100€', '50': '50€', '20': '20€', '10': '10€', '5': '5€', '2': '2€', '1': '1€', '0.5': '0,50€' }" :key="key">
+            <td class="border p-1">{{ label }}</td><td class="border p-1">{{ q3CashAnswers[key] || '—' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-        <div class="overflow-x-auto">
-            <table class="min-w-full rounded-lg border text-sm shadow">
-                <thead class="bg-muted/40">
-                    <tr>
-                        <th class="px-3 py-2 text-left">Geldsorte</th>
-                        <th class="px-3 py-2 text-left">Soll</th>
-                        <th class="px-3 py-2 text-left">Eingabe</th>
-                        <th class="px-3 py-2 text-left">Punkte</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr v-for="criterion in questionThreeCriteria" :key="criterion.key">
-                        <td class="px-3 py-2">{{ criterion.label }}</td>
-                        <td class="px-3 py-2">{{ criterion.expected }}</td>
-                        <td class="px-3 py-2">
-                            <Input
-                                :model-value="values[criterion.key]"
-                                class="w-20"
-                                inputmode="numeric"
-                                @input="(event) => sanitizeAndSet(criterion.key, event)"
-                                @blur="persistValue(criterion.key)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">{{ toNumber(values[criterion.key]) === criterion.expected ? 1 : 0 }} / 1</td>
-                    </tr>
-                </tbody>
-                <tfoot>
-                    <tr class="bg-muted/30">
-                        <td class="px-3 py-2 font-semibold" colspan="3">Aufgabe 3 Gesamt</td>
-                        <td class="px-3 py-2 font-bold">{{ questionThreeTotal }} / 8</td>
-                    </tr>
-                </tfoot>
-            </table>
-        </div>
+    <section class="space-y-3">
+      <h3 class="text-lg font-semibold">BT – Aufgabe 4</h3>
+      <table class="min-w-full rounded-lg border text-sm shadow">
+        <thead><tr><th class="border p-1 text-left">Ordner-Nr.</th><th v-for="i in 10" :key="`h-${i}`" class="border p-1">{{ i }}</th></tr></thead>
+        <tbody>
+          <tr><td class="border p-1">Buchstaben</td><td v-for="i in 10" :key="`f-${i}`" class="border p-1">{{ q4FolderAnswers[i] || '—' }}</td></tr>
+        </tbody>
+      </table>
+    </section>
 
-        <h3 class="text-lg font-semibold">BT – Aufgabe 4 (Scoring)</h3>
-        <p class="text-sm text-muted-foreground">
-            Punktvergabe: 1–4 richtige Ordner = 2 P., 5–9 = 4 P., 10 = 6 P.; bei 10 Ordnern zusätzlich alphabetische Reihenfolge eingehalten = +1 P.,
-            Ordner-Reihenfolge eingehalten = +1 P.
-        </p>
-        <div class="overflow-x-auto">
-            <table class="min-w-full rounded-lg border text-sm shadow">
-                <thead class="bg-muted/40">
-                    <tr>
-                        <th class="px-3 py-2 text-left">Kriterium</th>
-                        <th class="px-3 py-2 text-left">Eingabe</th>
-                        <th class="px-3 py-2 text-left">Punkte</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="px-3 py-2">Richtig verteilte Ordner (0–10)</td>
-                        <td class="px-3 py-2">
-                            <Input
-                                :model-value="values[scoreKeys.q4CorrectFolderCount]"
-                                class="w-20"
-                                inputmode="numeric"
-                                @input="(event) => sanitizeAndSet(scoreKeys.q4CorrectFolderCount, event)"
-                                @blur="persistValue(scoreKeys.q4CorrectFolderCount)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">{{ questionFourBasePoints }} / 6</td>
-                    </tr>
-                    <tr>
-                        <td class="px-3 py-2">Alphabetische Reihenfolge eingehalten</td>
-                        <td class="px-3 py-2">
-                            <input
-                                v-model="q4AlphabeticalOrderMet"
-                                type="checkbox"
-                                class="h-4 w-4 align-middle"
-                                @change="persistBooleanValue(scoreKeys.q4AlphabeticalOrderMet, q4AlphabeticalOrderMet)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">{{ questionFourAlphabeticalPoints }} / 1</td>
-                    </tr>
-                    <tr>
-                        <td class="px-3 py-2">Ordner-Reihenfolge eingehalten</td>
-                        <td class="px-3 py-2">
-                            <input
-                                v-model="q4FolderOrderMet"
-                                type="checkbox"
-                                class="h-4 w-4 align-middle"
-                                @change="persistBooleanValue(scoreKeys.q4FolderOrderMet, q4FolderOrderMet)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">{{ questionFourFolderOrderPoints }} / 1</td>
-                    </tr>
-                </tbody>
-                <tfoot>
-                    <tr class="bg-muted/30">
-                        <td class="px-3 py-2 font-semibold" colspan="2">Aufgabe 4 Gesamt</td>
-                        <td class="px-3 py-2 font-bold">{{ questionFourTotal }} / 8</td>
-                    </tr>
-                </tfoot>
-            </table>
-        </div>
+    <section class="space-y-3">
+      <h3 class="text-lg font-semibold">BT – Aufgabe 5</h3>
+      <table class="min-w-full rounded-lg border text-sm shadow">
+        <thead><tr><th class="border p-1 text-left">Tag</th><th class="border p-1 text-left">Markiert</th></tr></thead>
+        <tbody><tr v-for="day in 10" :key="day"><td class="border p-1">{{ day }}.AT</td><td class="border p-1">{{ q5StampDays[day] ? 'X' : '—' }}</td></tr></tbody>
+      </table>
+    </section>
 
-        <h3 class="text-lg font-semibold">BT – Aufgabe 5 (Scoring)</h3>
-        <p class="text-sm text-muted-foreground">
-            Punktvergabe Form A: 5. Tag = 2 P., 7. Tag = 2 P., 10. Tag = 4 P.
-        </p>
-        <div class="overflow-x-auto">
-            <table class="min-w-full rounded-lg border text-sm shadow">
-                <thead class="bg-muted/40">
-                    <tr>
-                        <th class="px-3 py-2 text-left">Arbeitstag</th>
-                        <th class="px-3 py-2 text-left">Markiert</th>
-                        <th class="px-3 py-2 text-left">Punkte</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr v-for="entry in q5DayEntries" :key="entry.key">
-                        <td class="px-3 py-2">{{ entry.day }}. AT</td>
-                        <td class="px-3 py-2">
-                            <input
-                                v-model="q5SelectedDays[entry.day]"
-                                type="checkbox"
-                                class="h-4 w-4 align-middle"
-                                @change="persistQ5DayValue(entry.day)"
-                            />
-                        </td>
-                        <td class="px-3 py-2 font-semibold">
-                            {{ q5SelectedDays[entry.day] && q5CorrectDays.has(entry.day) ? q5DayPoints[entry.day] ?? 0 : 0 }}
-                            / {{ q5DayPoints[entry.day] ?? 0 }}
-                        </td>
-                    </tr>
-                </tbody>
-                <tfoot>
-                    <tr class="bg-muted/30">
-                        <td class="px-3 py-2 font-semibold" colspan="2">Aufgabe 5 Gesamt</td>
-                        <td class="px-3 py-2 font-bold">{{ questionFiveTotal }} / 8</td>
-                    </tr>
-                </tfoot>
-            </table>
-        </div>
-    </div>
+    <section class="space-y-3">
+      <h3 class="text-lg font-semibold">BT – Aufgabe 6</h3>
+      <table class="min-w-full rounded-lg border text-sm shadow">
+        <thead><tr><th class="border p-1">von</th><th class="border p-1">nach</th><th class="border p-1">Zeit (Weg)</th><th class="border p-1">Zeit (Nachr.)</th></tr></thead>
+        <tbody>
+          <tr v-for="row in 6" :key="row">
+            <td class="border p-1">{{ q6RouteAssignments[`route-from-${row}`] || '—' }}</td>
+            <td class="border p-1">{{ q6RouteAssignments[`route-to-${row}`] || '—' }}</td>
+            <td class="border p-1">{{ q6RouteTimes[`route-time-${row}`] || '—' }}</td>
+            <td class="border p-1">{{ q6RouteTimes[`route-msg-${row}`] || '—' }}</td>
+          </tr>
+          <tr>
+            <td class="border p-1 text-right" colspan="2">Gesamtzeit</td>
+            <td class="border p-1">{{ q6RouteTotals.totalWay || '—' }}</td>
+            <td class="border p-1">{{ q6RouteTotals.totalMsg || '—' }}</td>
+          </tr>
+          <tr>
+            <td class="border p-1 text-right" colspan="2">Rückweg</td>
+            <td class="border p-1">{{ q6RouteTotals.returnWay || '—' }}</td>
+            <td class="border p-1">—</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
 </template>

--- a/resources/js/components/PdfTemplate.vue
+++ b/resources/js/components/PdfTemplate.vue
@@ -54,7 +54,8 @@ const testDate = new Date().toLocaleDateString('de-DE', {
           :model-value="assignment.results[0].result_json"
           :participant-profile="participant?.participant_profile"
           :manual-scores="assignment.results[0].manual_scores ?? []"
-          :show-answers="false"
+          :show-answers="assignment.test.name === 'BT'"
+          :force-open-answers="assignment.test.name === 'BT'"
         />
         <div v-else class="text-center text-gray-500">
           <p>Keine Ergebnisse verfügbar.</p>

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -217,6 +217,7 @@ const fpiRohwerte = computed(() => {
           :test-result-id="testResultId"
           :manual-scores="manualScoreMap"
           :results="local"
+          :show-answers="showAnswers"
           @manual-score-updated="handleManualScoreUpdated"
         />
         <AvemResult v-else-if="test.name === 'AVEM'" :results="local" />

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -216,6 +216,7 @@ const fpiRohwerte = computed(() => {
           v-else-if="test.name === 'BT'"
           :test-result-id="testResultId"
           :manual-scores="manualScoreMap"
+          :results="local"
           @manual-score-updated="handleManualScoreUpdated"
         />
         <AvemResult v-else-if="test.name === 'AVEM'" :results="local" />

--- a/resources/js/components/TestResultViewer.vue
+++ b/resources/js/components/TestResultViewer.vue
@@ -45,6 +45,7 @@ const props = withDefaults(
     test: { name: string };
     participantProfile?: { age: number; sex?: string } | null;
     showAnswers?: boolean;
+    forceOpenAnswers?: boolean;
     testResultId?: number | null;
     manualScores?: Array<{ key: string; value: number | string | null }> | Record<string, any>;
   }>(),
@@ -218,6 +219,7 @@ const fpiRohwerte = computed(() => {
           :manual-scores="manualScoreMap"
           :results="local"
           :show-answers="showAnswers"
+          :force-open-answers="forceOpenAnswers"
           @manual-score-updated="handleManualScoreUpdated"
         />
         <AvemResult v-else-if="test.name === 'AVEM'" :results="local" />

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { Button } from '@/components/ui/button';
 import { Head } from '@inertiajs/vue3';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
-const emit = defineEmits(['started']);
+const emit = defineEmits(['started', 'complete', 'update:answers']);
 
 type Restriction = 'F' | 'S' | null;
 
@@ -536,6 +536,30 @@ const debugScores = computed(() => {
     },
   };
 });
+
+
+const btResultPayload = computed(() => ({
+  assignments: { ...assignments.value },
+  cash_answers: { ...cashAnswers.value },
+  folder_answers: { ...folderAnswers.value },
+  stamp_answer_days: { ...stampAnswerDays.value },
+  route_assignments: { ...routeAssignments.value },
+  route_times: { ...routeTimes.value },
+  route_totals: { ...routeTotals.value },
+  scoring: debugScores.value,
+}));
+
+watch(
+  btResultPayload,
+  (payload) => {
+    emit('update:answers', payload);
+  },
+  { immediate: true, deep: true },
+);
+
+function completeBtTest() {
+  emit('complete', btResultPayload.value);
+}
 if (import.meta.env.DEV) {
   (globalThis as { __btDebugScores?: unknown }).__btDebugScores = debugScores;
 }
@@ -547,7 +571,8 @@ if (import.meta.env.DEV) {
   <div class="relative h-screen overflow-hidden bg-background text-black">
     <div v-if="showTest" class="absolute right-6 top-4 flex items-center gap-2">
       <Button variant="outline" @click="prevPage" :disabled="page === 1">Zurück</Button>
-      <Button @click="nextPage" :disabled="page === maxPage">Weiter</Button>
+      <Button v-if="page < maxPage" @click="nextPage">Weiter</Button>
+      <Button v-else @click="completeBtTest">Test beenden</Button>
     </div>
     <div v-if="showTest"
       class="absolute bottom-4 left-4 z-20 w-[900px] max-w-[calc(100%-2rem)] rounded-lg border border-black bg-white/95 p-3 font-sans text-xs shadow-lg">
@@ -629,7 +654,7 @@ if (import.meta.env.DEV) {
           Sollten Sie einmal bei einer Aufgabe nicht zurechtkommen, so versuchen Sie wenigstens, einen Ansatz zu finden
           und einzutragen. Versäumen Sie bei den leichten Aufgaben am Anfang nicht zu viel Zeit, da Ihnen dann nachher
           bei den umfangreicheren Aufgaben 4-6 Zeit fehlen muss. Halten Sie sich nicht zu lange bei einer Aufgabe auf.
-          Sie haben 30 Minuten Zeit für sechs Aufgaben.
+          Sie haben 60 Minuten Zeit für sechs Aufgaben.
         </p>
         <div class="pt-2 text-center">
           <Button class="px-8" @click="startTest">Test starten</Button>

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -4,6 +4,9 @@ import { Head } from '@inertiajs/vue3';
 import { computed, ref, watch } from 'vue';
 
 const emit = defineEmits(['started', 'complete', 'update:answers']);
+const props = defineProps<{
+  timeRemainingSeconds?: number | null;
+}>();
 
 type Restriction = 'F' | 'S' | null;
 
@@ -65,6 +68,9 @@ const rightNames = computed(() => apprentices.value.slice(13));
 const maxPage = 6;
 const page = ref(1);
 const showTest = ref(false);
+const startedAtMs = ref<number | null>(null);
+const startTimeRemainingSeconds = ref<number | null>(null);
+const latestTimeRemainingSeconds = ref<number | null>(null);
 const cashDenominations = [
   { label: '100€', key: '100' },
   { label: '50€', key: '50' },
@@ -257,6 +263,29 @@ function handleRouteTotalInput(key: 'totalWay' | 'totalMsg' | 'returnWay', event
   target.value = cleaned;
 }
 
+
+watch(
+  () => props.timeRemainingSeconds,
+  (value) => {
+    if (typeof value !== 'number') return;
+    latestTimeRemainingSeconds.value = Math.max(0, Math.floor(value));
+    if (showTest.value && startTimeRemainingSeconds.value === null) {
+      startTimeRemainingSeconds.value = latestTimeRemainingSeconds.value;
+    }
+  },
+  { immediate: true },
+);
+
+function getElapsedSeconds() {
+  if (startTimeRemainingSeconds.value != null && latestTimeRemainingSeconds.value != null) {
+    return Math.max(0, startTimeRemainingSeconds.value - latestTimeRemainingSeconds.value);
+  }
+  if (startedAtMs.value != null) {
+    return Math.max(0, Math.floor((Date.now() - startedAtMs.value) / 1000));
+  }
+  return null;
+}
+
 function nextPage() {
   if (page.value < maxPage) {
     page.value += 1;
@@ -273,6 +302,12 @@ function startTest() {
   emit('started');
   showTest.value = true;
   page.value = 1;
+  startedAtMs.value = Date.now();
+  if (typeof props.timeRemainingSeconds === 'number') {
+    const remaining = Math.max(0, Math.floor(props.timeRemainingSeconds));
+    startTimeRemainingSeconds.value = remaining;
+    latestTimeRemainingSeconds.value = remaining;
+  }
 }
 
 function normalizeFolderLetters(value: string) {
@@ -547,6 +582,7 @@ const btResultPayload = computed(() => ({
   route_times: { ...routeTimes.value },
   route_totals: { ...routeTotals.value },
   scoring: debugScores.value,
+  total_time_seconds: getElapsedSeconds(),
 }));
 
 watch(


### PR DESCRIPTION
### Motivation
- Provide a BT result page matching other tests that shows participant answers per Aufgabe in read-only tables and allow the Prüfer to enter Aufgabe 2 points manually.
- Make the BT test stay consistent with the requested 60 minute duration and provide an explicit end action on the final page.

### Description
- Added a structured BT payload and emitter in `resources/js/pages/BT.vue` so the test publishes `update:answers` continuously and emits `complete` with the full BT payload when the last page `Test beenden` button is pressed, and updated the intro text to `60 Minuten`.
- Implemented `resources/js/components/BtResult.vue` to render read-only tables for Aufgaben 1, 3, 4, 5 and 6 and a single manual input for Aufgabe 2 (`bt_q2_manual_points`) that persists via the existing manual-scores API and emits `manual-score-updated`.
- Wired the BT results into the result viewer by passing `:results=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b9a0c868832998832678c0a20742)