### PR TITLE
Adjust Aufgabe 2 typography and add German sentence-start template

### DIFF
--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -890,12 +890,12 @@ if (import.meta.env.DEV) {
       </div>
     </div>
 
-    <div v-else-if="page === 2" class="flex h-full flex-col px-12 py-8 font-serif text-base">
+    <div v-else-if="page === 2" class="flex h-full flex-col px-12 py-8 font-serif text-xl">
       <div class="text-center">
         <h1 class="text-xl font-semibold tracking-[0.4em]">Aufgabe 2</h1>
       </div>
       <div class="mt-10 flex flex-1 flex-col items-center">
-        <div class="max-w-2xl text-center space-y-4 leading-relaxed">
+        <div class="max-w-2xl space-y-4 text-center leading-relaxed">
           <p>
             Sie erhalten ungeordnet 220 Kopien von Rechnungen aus den Orten Essen, Düsseldorf und Köln.
           </p>
@@ -907,15 +907,22 @@ if (import.meta.env.DEV) {
           <div class="space-y-2">
             <p>b) welche bereits bezahlt und welche noch unbezahlt sind</p>
             <div class="flex flex-wrap items-center gap-4 pl-6">
-              <p class="text-base">Bezahlte Rechnungen haben entsprechenden Stempelaufdruck</p>
+              <p>Bezahlte Rechnungen haben entsprechenden Stempelaufdruck</p>
               <div class="border border-black px-4 py-1 text-sm tracking-[0.5em]">BEZAHLT</div>
             </div>
           </div>
           <p>c) welche Höhe die unbezahlten Rechnungen insgesamt haben.</p>
         </div>
-        <p class="mt-10 max-w-2xl text-center">
-          Geben Sie bitte auf dem Lösungsblatt in Stichworten an, wie Sie diese Aufgabe anpacken würden.
-        </p>
+        <div class="mt-10 max-w-2xl space-y-4 text-center">
+          <p>Geben Sie bitte auf dem Lösungsblatt in Stichworten an, wie Sie diese Aufgabe anpacken würden.</p>
+          <p>Bitte beginnen Sie Ihren Satz wie unten gezeigt.</p>
+          <p>
+            Ich werde zuerst ___________________________________________________________________<br>
+            _____________________________________________________________________________________________________<br>
+            _____________________________________________________________________________________________________<br>
+            und zum Schluss ___________________________________________________________________________________
+          </p>
+        </div>
       </div>
     </div>
     <div v-else-if="page === 3" class="flex h-full flex-col">

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -908,7 +908,7 @@ if (import.meta.env.DEV) {
             <p>b) welche bereits bezahlt und welche noch unbezahlt sind</p>
             <div class="flex flex-wrap items-center gap-4 pl-6">
               <p>Bezahlte Rechnungen haben entsprechenden Stempelaufdruck</p>
-              <div class="border border-black px-4 py-1 text-sm tracking-[0.5em]">BEZAHLT</div>
+              <div class="border border-black px-4 py-1 text-xl tracking-[0.5em]">BEZAHLT</div>
             </div>
           </div>
           <p>c) welche Höhe die unbezahlten Rechnungen insgesamt haben.</p>

--- a/resources/js/pages/BT.vue
+++ b/resources/js/pages/BT.vue
@@ -913,15 +913,21 @@ if (import.meta.env.DEV) {
           </div>
           <p>c) welche Höhe die unbezahlten Rechnungen insgesamt haben.</p>
         </div>
-        <div class="mt-10 max-w-2xl space-y-4 text-center">
+        <div class="mt-10 w-full max-w-4xl space-y-4 text-left">
           <p>Geben Sie bitte auf dem Lösungsblatt in Stichworten an, wie Sie diese Aufgabe anpacken würden.</p>
           <p>Bitte beginnen Sie Ihren Satz wie unten gezeigt.</p>
-          <p>
-            Ich werde zuerst ___________________________________________________________________<br>
-            _____________________________________________________________________________________________________<br>
-            _____________________________________________________________________________________________________<br>
-            und zum Schluss ___________________________________________________________________________________
-          </p>
+          <div class="space-y-4 pt-2">
+            <p class="flex items-end gap-2">
+              <span>Ich werde zuerst</span>
+              <span class="block flex-1 border-b border-black">&nbsp;</span>
+            </p>
+            <p class="border-b border-black">&nbsp;</p>
+            <p class="border-b border-black">&nbsp;</p>
+            <p class="flex items-end gap-2">
+              <span>und zum Schluss</span>
+              <span class="block flex-1 border-b border-black">&nbsp;</span>
+            </p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Make the instruction text in `Aufgabe 2` visually consistent with `Aufgabe 1` by increasing the container typography size. 
- Provide explicit, German-language sentence-start guidance so examinees know how to begin their written answer.

### Description
- Changed the `page === 2` container class from `text-base` to `text-xl` in `resources/js/pages/BT.vue` to match `Aufgabe 1` typography. 
- Removed an extra `text-base` class on a nested paragraph to avoid conflicting sizing. 
- Added the line `Bitte beginnen Sie Ihren Satz wie unten gezeigt.` and appended the requested multi-line sentence-starter template beginning with `Ich werde zuerst ...` and ending with `und zum Schluss ...` inside a centered block. 
- Preserved existing layout and styling while grouping the final instructions into a `max-w-2xl` centered section.

### Testing
- Ran `git diff -- resources/js/pages/BT.vue` to review the changes and the diff output matched the intended template modifications (succeeded). 
- Ran `git status --short` to confirm the working tree and then committed the change with `git commit` (succeeded). 
- No automated unit or integration tests were added or run because this is a content/style-only template update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d9d048f4832982f2626201508772)