### PR TITLE
Implement Participant Age Validation (16-80 years)

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -68,8 +68,8 @@ class ParticipantController extends Controller
       'employed_id'          => 'nullable|exists:employeds,id',
       'profession_group_id'  => 'nullable|exists:profession_groups,id',
     ], [
-      'birthday.before_or_equal' => __('Das Mindestalter für die Teilnahme beträgt 16 Jahre.'),
-      'birthday.after_or_equal' => __('Das Höchstalter für die Teilnahme beträgt 80 Jahre.'),
+      'birthday.before_or_equal' => __('Bitte geben Sie ein gültiges Datum ein.'),
+      'birthday.after_or_equal' => __('Bitte geben Sie ein gültiges Datum ein.'),
     ]);
 
     $data['age'] = \Carbon\Carbon::parse($data['birthday'])->age;

--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -58,10 +58,18 @@ class ParticipantController extends Controller
     $user = Auth::user();
 
     $data = $request->validate([
-      'birthday'             => 'required|date',
+      'birthday'             => [
+        'required',
+        'date',
+        'before_or_equal:' . now()->subYears(16)->format('Y-m-d'),
+        'after_or_equal:' . now()->subYears(80)->format('Y-m-d'),
+      ],
       'sex'                  => 'required|string|max:255',
       'employed_id'          => 'nullable|exists:employeds,id',
       'profession_group_id'  => 'nullable|exists:profession_groups,id',
+    ], [
+      'birthday.before_or_equal' => __('Das Mindestalter für die Teilnahme beträgt 16 Jahre.'),
+      'birthday.after_or_equal' => __('Das Höchstalter für die Teilnahme beträgt 80 Jahre.'),
     ]);
 
     $data['age'] = \Carbon\Carbon::parse($data['birthday'])->age;

--- a/resources/js/pages/Participant.vue
+++ b/resources/js/pages/Participant.vue
@@ -34,6 +34,7 @@ const flash = computed(() => page.props.flash)
 watch(() => form.birthday, val => {
   if (!val) {
     form.age = ''
+    form.clearErrors('birthday')
     return
   }
   const bday = new Date(val)
@@ -43,12 +44,10 @@ watch(() => form.birthday, val => {
   form.age = age
 
   // Basic client-side validation logic
-  if (age < 16) {
-    form.errors.birthday = 'Das Mindestalter für die Teilnahme beträgt 16 Jahre.'
-  } else if (age > 80) {
-    form.errors.birthday = 'Das Höchstalter für die Teilnahme beträgt 80 Jahre.'
+  if (age < 16 || age > 80) {
+    form.errors.birthday = 'Bitte geben Sie ein gültiges Datum ein.'
   } else {
-    delete form.errors.birthday
+    form.clearErrors('birthday')
   }
 })
 

--- a/resources/js/pages/Participant.vue
+++ b/resources/js/pages/Participant.vue
@@ -32,15 +32,30 @@ const flash = computed(() => page.props.flash)
 
 // Age calculation
 watch(() => form.birthday, val => {
-  if (!val) return form.age = ''
+  if (!val) {
+    form.age = ''
+    return
+  }
   const bday = new Date(val)
   let age = today.getFullYear() - bday.getFullYear()
   const m = today.getMonth() - bday.getMonth()
   if (m < 0 || (m === 0 && today.getDate() < bday.getDate())) age--
   form.age = age
+
+  // Basic client-side validation logic
+  if (age < 16) {
+    form.errors.birthday = 'Das Mindestalter für die Teilnahme beträgt 16 Jahre.'
+  } else if (age > 80) {
+    form.errors.birthday = 'Das Höchstalter für die Teilnahme beträgt 80 Jahre.'
+  } else {
+    delete form.errors.birthday
+  }
 })
 
 function submit() {
+  if (form.age < 16 || form.age > 80) {
+    return
+  }
   form.post('/onboarding')
 }
 


### PR DESCRIPTION
I have implemented age validation for the participant onboarding process. 

Key changes:
1. **Backend Validation**: Updated `ParticipantController@storeProfile` to enforce that participants must be between 16 and 80 years old. If a date like 07.05.1455 is entered, the server will now return a validation error instead of crashing.
2. **Frontend Validation**: Added a watcher in `Participant.vue` to calculate age in real-time and display German error messages if the age is outside the allowed range. The "Speichern & Weiter" button is also guarded against invalid ages.
3. **User Experience**: The validation uses the project's existing error handling patterns to ensure a consistent look and feel.

---
*PR created automatically by Jules for task [2146511209240490724](https://jules.google.com/task/2146511209240490724) started by @miqr-dev*