### PR TITLE
Stop auto-starting the first test after "Prüfung starten"

### DIFF
--- a/app/Http/Controllers/ExamController.php
+++ b/app/Http/Controllers/ExamController.php
@@ -170,38 +170,13 @@ class ExamController extends Controller
       return back(303)->with('error', 'Exam has no steps.');
     }
 
-    $firstStep = $exam->steps()->orderBy('step_order')->first();
-
     $exam->update([
       'status' => 'in_progress',
-      'current_exam_step_id' => $firstStep->id,
+      'current_exam_step_id' => null,
       'started_at' => now(),
     ]);
 
-    // Create status records for all participants for the first step
-    $exam->load('participants');
-    $participantIds = $exam->participants->pluck('participant_id');
-    $completedAssignments = collect();
-    if ($firstStep->test_id) {
-      $completedAssignments = TestAssignment::where('test_id', $firstStep->test_id)
-        ->whereIn('participant_id', $participantIds)
-        ->where('status', 'completed')
-        ->whereHas('results')
-        ->get(['participant_id', 'completed_at'])
-        ->keyBy('participant_id');
-    }
-    foreach ($exam->participants as $participant) {
-      $completedAssignment = $completedAssignments->get($participant->participant_id);
-      $isCompleted = $completedAssignment !== null;
-      ExamStepStatus::create([
-        'exam_id' => $exam->id,
-        'exam_step_id' => $firstStep->id,
-        'participant_id' => $participant->participant_id,
-        'status' => $isCompleted ? 'completed' : 'not_started',
-        'completed_at' => $isCompleted ? ($completedAssignment->completed_at ?? now()) : null,
-      ]);
-    }
-    return back(303)->with('success', 'Exam started!');
+    return back(303)->with('success', 'Exam started. Select a test to begin.');
   }
 
   public function nextStep(Exam $exam)
@@ -270,12 +245,16 @@ class ExamController extends Controller
       'step_id' => 'required|exists:exam_steps,id',
     ]);
 
+    $step = $exam->steps()->whereKey($data['step_id'])->first();
+    if (!$step) {
+      return back(303)->with('error', 'Selected step does not belong to this exam.');
+    }
+
     $exam->update(['current_exam_step_id' => $data['step_id']]);
 
     // Create status records for all participants for the new step
     $exam->load('participants');
     $participantIds = $exam->participants->pluck('participant_id');
-    $step = $exam->steps()->whereKey($data['step_id'])->first();
     $completedAssignments = collect();
     if ($step?->test_id) {
       $completedAssignments = TestAssignment::where('test_id', $step->test_id)

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -840,8 +840,7 @@ watch(
               <tr v-if="!visibleSteps.length">
                 <td colspan="3"
                   class="px-6 py-4 text-center text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                  Momentan sind keine Tests verfügbar. Bitte warten Sie, bis Ihre Prüfung startet oder der Prüfer den
-                  nächsten Test freigibt.
+                  Please wait.
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
### Motivation
- Teachers should explicitly choose which test to start after moving an exam to `in_progress` instead of the system automatically activating the first configured step.
- Participants should see a neutral waiting message while the teacher selects a test.

### Description
- Changed `ExamController::start()` to set the exam `status` to `in_progress` and `current_exam_step_id` to `null`, and removed automatic creation/activation of the first step so no test starts automatically; response message now prompts the teacher to select a test to begin.
- Added a validation guard in `ExamController::setStep()` to ensure the selected `step_id` belongs to the given exam before activating it.
- Updated the participant empty-state copy in `resources/js/pages/Exams/ExamRoom.vue` to display `Please wait.` when no test is active.

### Testing
- `php -l app/Http/Controllers/ExamController.php` succeeded with no syntax errors.
- `php -l app/Http/Controllers/ParticipantController.php` succeeded with no syntax errors.
- `npm run lint` was executed and failed due to many pre-existing lint errors unrelated to these changes (44 errors reported).
- `php artisan test` could not run in this environment because `vendor/autoload.php` is missing.
- `npm -s run -q typecheck` could not be executed because a `typecheck` script is not defined in this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb52c2d63c83298237f71d96ee5c63)