### PR TITLE
Confirm before ending live exam from dashboard

### DIFF
--- a/resources/js/components/LiveExamStatusTable.vue
+++ b/resources/js/components/LiveExamStatusTable.vue
@@ -215,6 +215,13 @@ const setStatus = (status: string) => {
   })
 }
 
+const confirmAndFinishExam = () => {
+  const confirmed = window.confirm('Sind Sie sicher, dass Sie die Prüfung beenden möchten? Es gibt kein Zurück.')
+  if (!confirmed) return
+
+  setStatus('completed')
+}
+
 const getParticipantUserId = (participant: any) =>
   participant.participant_id ?? participant.user?.id
 
@@ -381,7 +388,7 @@ const canForceFinishParticipant = (participant: any) => {
             <Button v-else-if="exam.status === 'paused'" size="sm" @click="setStatus('in_progress')">
               Prüfung fortsetzen
             </Button>
-            <Button v-if="exam.status !== 'completed'" size="sm" @click="setStatus('completed')">
+            <Button v-if="exam.status !== 'completed'" size="sm" @click="confirmAndFinishExam">
               Prüfung beenden
             </Button>
           </div>


### PR DESCRIPTION
### Motivation
- Prevent accidental exam termination when clicking "Prüfung beenden" in the Live Exams ("Laufende Prüfungen") dashboard by adding an explicit confirmation step.

### Description
- Add a `confirmAndFinishExam` helper that shows `window.confirm` and only calls the existing `setStatus('completed')` when the user confirms.
- Update the dashboard "Prüfung beenden" button to call `confirmAndFinishExam` instead of directly calling `setStatus('completed')`.
- The change is limited to `resources/js/components/LiveExamStatusTable.vue`.

### Testing
- Ran `npx eslint resources/js/components/LiveExamStatusTable.vue`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6e53e0b083298b4832c07cca4f56)