### PR TITLE
Remove redundant 'Prüfung beenden' button from live exam dashboard

### DIFF
--- a/resources/js/components/LiveExamStatusTable.vue
+++ b/resources/js/components/LiveExamStatusTable.vue
@@ -215,6 +215,13 @@ const setStatus = (status: string) => {
   })
 }
 
+const confirmAndFinishExam = () => {
+  const confirmed = window.confirm('Sind Sie sicher, dass Sie die Prüfung beenden möchten? Es gibt kein Zurück.')
+  if (!confirmed) return
+
+  setStatus('completed')
+}
+
 const getParticipantUserId = (participant: any) =>
   participant.participant_id ?? participant.user?.id
 
@@ -375,11 +382,11 @@ const canForceFinishParticipant = (participant: any) => {
             <Button v-if="exam.status === 'not_started'" size="sm" @click="startExam">
               Prüfung starten
             </Button>
-            <Button v-if="exam.status === 'in_progress'" size="sm" @click="setStatus('paused')">
-              Prüfung pausieren
-            </Button>
-            <Button v-else-if="exam.status === 'paused'" size="sm" @click="setStatus('in_progress')">
+            <Button v-if="exam.status === 'paused'" size="sm" @click="setStatus('in_progress')">
               Prüfung fortsetzen
+            </Button>
+            <Button v-if="exam.status !== 'completed'" size="sm" @click="confirmAndFinishExam">
+              Prüfung beenden
             </Button>
           </div>
         </div>

--- a/resources/js/components/LiveExamStatusTable.vue
+++ b/resources/js/components/LiveExamStatusTable.vue
@@ -215,13 +215,6 @@ const setStatus = (status: string) => {
   })
 }
 
-const confirmAndFinishExam = () => {
-  const confirmed = window.confirm('Sind Sie sicher, dass Sie die Prüfung beenden möchten? Es gibt kein Zurück.')
-  if (!confirmed) return
-
-  setStatus('completed')
-}
-
 const getParticipantUserId = (participant: any) =>
   participant.participant_id ?? participant.user?.id
 
@@ -387,9 +380,6 @@ const canForceFinishParticipant = (participant: any) => {
             </Button>
             <Button v-else-if="exam.status === 'paused'" size="sm" @click="setStatus('in_progress')">
               Prüfung fortsetzen
-            </Button>
-            <Button v-if="exam.status !== 'completed'" size="sm" @click="confirmAndFinishExam">
-              Prüfung beenden
             </Button>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Remove a misleading dashboard-level "Prüfung beenden" action that finished the entire exam from the pause/manage area.

### Description
- Deleted the top-level `Prüfung beenden` button and removed the now-unused `confirmAndFinishExam` helper in `resources/js/components/LiveExamStatusTable.vue`.

### Testing
- Ran `npx eslint resources/js/components/LiveExamStatusTable.vue`, which completed successfully (only an npm environment warning was printed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7109d0908329862a1f541a677339)