### PR TITLE
Hide Prüfer section in generated result PDF

### DIFF
--- a/resources/js/components/PdfTemplate.vue
+++ b/resources/js/components/PdfTemplate.vue
@@ -2,70 +2,69 @@
 import TestResultViewer from '@/components/TestResultViewer.vue';
 
 defineProps<{
-  assignment: any;
-  participant: any;
-  teacherName: string;
+    assignment: any;
+    participant: any;
+    teacherName: string;
+    showTeacher?: boolean;
 }>();
 
 const testDate = new Date().toLocaleDateString('de-DE', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
 });
 </script>
 
 <template>
-  <div class="bg-white text-black p-8 font-sans">
-    <!-- Header -->
-    <div class="flex justify-between items-center pb-4 border-b-2 border-gray-200">
-      <div>
-        <h1 class="text-3xl font-bold">Testergebnis</h1>
-        <p class="text-gray-600">{{ assignment.test.name }}</p>
-      </div>
-      <div class="text-right">
-        <p class="text-gray-600">Datum: {{ testDate }}</p>
-      </div>
-    </div>
-
-    <!-- Participant and Teacher Info -->
-    <div class="grid grid-cols-2 gap-4 mt-8">
-      <div>
-        <h2 class="text-xl font-semibold mb-2">Teilnehmer/in</h2>
-        <p v-if="participant">
-          {{ participant.name }}
-        </p>
-        <p v-else>
-          N/A
-        </p>
-      </div>
-      <div>
-        <h2 class="text-xl font-semibold mb-2">Prüfer/in</h2>
-        <p>{{ teacherName }}</p>
-      </div>
-    </div>
-
-    <!-- Results -->
-    <div class="mt-8">
-      <h2 class="text-xl font-semibold mb-4">Auswertung</h2>
-      <div class="p-4 border rounded-lg bg-gray-50">
-        <TestResultViewer
-          v-if="assignment && assignment.results.length > 0"
-          :test="assignment.test"
-          :model-value="assignment.results[0].result_json"
-          :participant-profile="participant?.participant_profile"
-          :manual-scores="assignment.results[0].manual_scores ?? []"
-          :show-answers="assignment.test.name === 'BT'"
-          :force-open-answers="assignment.test.name === 'BT'"
-        />
-        <div v-else class="text-center text-gray-500">
-          <p>Keine Ergebnisse verfügbar.</p>
+    <div class="bg-white p-8 font-sans text-black">
+        <!-- Header -->
+        <div class="flex items-center justify-between border-b-2 border-gray-200 pb-4">
+            <div>
+                <h1 class="text-3xl font-bold">Testergebnis</h1>
+                <p class="text-gray-600">{{ assignment.test.name }}</p>
+            </div>
+            <div class="text-right">
+                <p class="text-gray-600">Datum: {{ testDate }}</p>
+            </div>
         </div>
-      </div>
-    </div>
 
-    <!-- Footer -->
-    <!-- <div class="mt-12 text-center text-gray-500 text-sm">
+        <!-- Participant and Teacher Info -->
+        <div class="mt-8 grid grid-cols-2 gap-4">
+            <div>
+                <h2 class="mb-2 text-xl font-semibold">Teilnehmer/in</h2>
+                <p v-if="participant">
+                    {{ participant.name }}
+                </p>
+                <p v-else>N/A</p>
+            </div>
+            <div v-if="showTeacher">
+                <h2 class="mb-2 text-xl font-semibold">Prüfer/in</h2>
+                <p>{{ teacherName }}</p>
+            </div>
+        </div>
+
+        <!-- Results -->
+        <div class="mt-8">
+            <h2 class="mb-4 text-xl font-semibold">Auswertung</h2>
+            <div class="rounded-lg border bg-gray-50 p-4">
+                <TestResultViewer
+                    v-if="assignment && assignment.results.length > 0"
+                    :test="assignment.test"
+                    :model-value="assignment.results[0].result_json"
+                    :participant-profile="participant?.participant_profile"
+                    :manual-scores="assignment.results[0].manual_scores ?? []"
+                    :show-answers="assignment.test.name === 'BT'"
+                    :force-open-answers="assignment.test.name === 'BT'"
+                />
+                <div v-else class="text-center text-gray-500">
+                    <p>Keine Ergebnisse verfügbar.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Footer -->
+        <!-- <div class="mt-12 text-center text-gray-500 text-sm">
       <p>Dieses Dokument wurde automatisch generiert.</p>
     </div> -->
-  </div>
+    </div>
 </template>

--- a/resources/js/components/TestResultModal.vue
+++ b/resources/js/components/TestResultModal.vue
@@ -31,6 +31,7 @@ const teacherName = computed(() => {
 });
 
 const isAvemTest = computed(() => props.assignment?.test?.name === 'AVEM');
+const showTeacherInPdf = false;
 
 const pdfContainerStyle = computed(() => ({
     zIndex: -1,
@@ -161,6 +162,13 @@ async function downloadUnifiedPdf() {
 
     <!-- Hidden template for PDF generation -->
     <div v-if="isGeneratingPdf" class="fixed top-0 left-0" :style="pdfContainerStyle">
-        <PdfTemplate v-if="assignment" ref="pdfTemplateRef" :assignment="assignment" :participant="participant" :teacherName="teacherName" />
+        <PdfTemplate
+            v-if="assignment"
+            ref="pdfTemplateRef"
+            :assignment="assignment"
+            :participant="participant"
+            :teacherName="teacherName"
+            :show-teacher="showTeacherInPdf"
+        />
     </div>
 </template>


### PR DESCRIPTION
### Motivation
- The generated result PDF currently shows the "Prüfer/in" label and name and this should be hidden for now while keeping the field available for re-activation later.

### Description
- Added an optional `showTeacher` prop to `resources/js/components/PdfTemplate.vue` and wrapped the entire "Prüfer/in" block behind `v-if="showTeacher"` so both label and name are hidden when false.
- Wired `resources/js/components/TestResultModal.vue` to pass `:show-teacher="showTeacherInPdf"` with `showTeacherInPdf = false` for PDF generation only so the app UI remains unchanged.
- Kept all other PDF content and the existing manual-review text (e.g., `Manuelle Bewertung durch Prüfer:in`) untouched.

### Testing
- Ran `npx prettier --write` on the modified files which completed successfully.
- Ran `npx eslint` on the touched files which failed due to an existing unrelated `vue/no-mutating-props` issue in `TestResultModal.vue` and not due to the new `showTeacher` flag.
- Committed the changes with message `Hide Prüfer section in generated result PDF` after formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2b90580c8329be1836ab5fa637a1)