### PR TITLE
Hide redundant "Änderungen speichern" button for read-only/autosave test results

### DIFF
--- a/resources/js/components/TestResultModal.vue
+++ b/resources/js/components/TestResultModal.vue
@@ -31,6 +31,7 @@ const teacherName = computed(() => {
 });
 
 const isAvemTest = computed(() => props.assignment?.test?.name === 'AVEM');
+const requiresMainSaveButton = computed(() => ['BRT-A', 'BRT-B'].includes(props.assignment?.test?.name));
 const showTeacherInPdf = false;
 
 const pdfContainerStyle = computed(() => ({
@@ -155,7 +156,7 @@ async function downloadUnifiedPdf() {
                 class="mb-4 flex-1 overflow-y-auto"
             />
             <DialogFooter>
-                <Button type="button" @click="submit">Änderungen speichern</Button>
+                <Button v-if="requiresMainSaveButton" type="button" @click="submit">Änderungen speichern</Button>
             </DialogFooter>
         </DialogContent>
     </Dialog>


### PR DESCRIPTION
### Motivation
- Remove the modal-level `Änderungen speichern` button for tests that are read-only or which already persist changes via their own autosave/manual-save controls, while keeping the button for tests that rely on the modal save (BRT-A and BRT-B). 

### Description
- In `resources/js/components/TestResultModal.vue` added a computed `requiresMainSaveButton` that returns `true` only for `['BRT-A', 'BRT-B']` and applied `v-if="requiresMainSaveButton"` to the footer save `Button`, so the main save button is only rendered for those tests.

### Testing
- Ran `npx prettier --check resources/js/components/TestResultModal.vue` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3261a7f88329893892fbf788bdad)