### PR TITLE
Filter dashboard active exams by user city

### DIFF
--- a/app/Http/Controllers/ExamController.php
+++ b/app/Http/Controllers/ExamController.php
@@ -282,8 +282,11 @@ class ExamController extends Controller
 
   public function getActiveExams()
   {
+    $user = Auth::user();
+
     $activeExams = Exam::with(['steps.test', 'currentStep.test'])
       ->whereIn('status', ['in_progress', 'paused'])
+      ->where('city_id', $user->city_id)
       ->get();
 
     if ($activeExams->isEmpty()) {


### PR DESCRIPTION
### Motivation
- The dashboard’s "Laufende Prüfungen" listed active exams from all cities because `ExamController::getActiveExams` did not restrict results by `city_id`, causing teachers and admins to see exams outside their city.

### Description
- Scope active exams to the logged-in user’s city by calling `Auth::user()` and adding `->where('city_id', $user->city_id)` to `ExamController::getActiveExams`, leaving the rest of the processing unchanged.

### Testing
- Ran `php -l app/Http/Controllers/ExamController.php`, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f308f2989883298829a9ad9911ed18)