### PR TITLE
Add FPI-R-style horizontal separators between LMT question rows

### DIFF
--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -272,15 +272,13 @@ const totalTimeTaken = computed(() => {
                 <div class="overflow-x-auto">
                     <table class="min-w-full table-fixed border-separate border-spacing-y-0 text-sm">
                         <tbody>
-                            <tr
-                                v-for="q in questionsOnPage"
-                                :key="q.number"
-                                class="border-t border-gray-300 border-b-2 border-gray-200 dark:border-gray-700"
-                            >
-                                <td class="w-1/2 py-4 pr-4 align-top font-medium whitespace-normal text-gray-800 dark:text-gray-200">
+                            <tr v-for="q in questionsOnPage" :key="q.number" class="border-t border-gray-300 dark:border-gray-700">
+                                <td
+                                    class="w-1/2 border-b-2 border-gray-200 py-4 pr-4 align-top font-medium whitespace-normal text-gray-800 dark:border-gray-700 dark:text-gray-200"
+                                >
                                     {{ q.number }}. {{ q.text }}
                                 </td>
-                                <td class="w-1/2 py-4 align-top">
+                                <td class="w-1/2 border-b-2 border-gray-200 py-4 align-top dark:border-gray-700">
                                     <div class="flex w-full flex-col gap-2">
                                         <label
                                             v-for="(opt, idx) in q.options"

--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -272,7 +272,11 @@ const totalTimeTaken = computed(() => {
                 <div class="overflow-x-auto">
                     <table class="min-w-full table-fixed border-separate border-spacing-y-0 text-sm">
                         <tbody>
-                            <tr v-for="q in questionsOnPage" :key="q.number" class="border-t border-gray-300 dark:border-gray-700">
+                            <tr
+                                v-for="q in questionsOnPage"
+                                :key="q.number"
+                                class="border-t border-gray-300 border-b-2 border-gray-200 dark:border-gray-700"
+                            >
                                 <td class="w-1/2 py-4 pr-4 align-top font-medium whitespace-normal text-gray-800 dark:text-gray-200">
                                     {{ q.number }}. {{ q.text }}
                                 </td>


### PR DESCRIPTION
### Motivation
- Make the paginated LMT question list visually match the FPI-R style by adding horizontal separators between each question row as requested by the UI specification.
- Keep the existing top-row divider (`border-t border-gray-300`) in place per the styling guidance.

### Description
- Updated `resources/js/pages/LMT.vue` to add `border-b-2 border-gray-200` to the `<tr>` rendering `questionsOnPage` so each question row has a bottom separator.
- Preserved the existing `border-t border-gray-300` and `dark:border-gray-700` classes so dark-mode and previous row styling remain unchanged.

### Testing
- No automated tests were run for this UI-only style adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3278befc48329b0b26afc31bf4774)