### PR TITLE
Fix LMT test duration calculation inflation

### DIFF
--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -92,6 +92,7 @@ const userAnswers = ref<(number | null)[]>(Array(questions.value.length).fill(nu
 const questionTimes = ref<number[]>(Array(questions.value.length).fill(0));
 const questionStartTimestamps = ref<(number | null)[]>(Array(questions.value.length).fill(null));
 const startTime = ref<number | null>(null);
+const finishTime = ref<number | null>(null);
 
 const totalPages = computed(() => Math.ceil(questions.value.length / questionsPerPage));
 
@@ -132,6 +133,7 @@ function startTest() {
     questionTimes.value = Array(questions.value.length).fill(0);
     questionStartTimestamps.value = Array(questions.value.length).fill(null);
     startTime.value = Date.now();
+    finishTime.value = null;
 
     // Start timing for visible questions
     questionsOnPage.value.forEach((q) => {
@@ -174,19 +176,32 @@ function startTimingCurrentPage() {
 
 function stopTimingCurrentPage() {
     const now = Date.now();
+    const questionsCount = questionsOnPage.value.length;
+    if (questionsCount === 0) return;
+
+    let pageStart: number | null = null;
     questionsOnPage.value.forEach((q) => {
-        const index = q.number - 1;
-        const start = questionStartTimestamps.value[index];
-        if (start) {
-            const elapsed = Math.round((now - start) / 1000);
-            questionTimes.value[index] += elapsed;
-            questionStartTimestamps.value[index] = null;
+        const start = questionStartTimestamps.value[q.number - 1];
+        if (start && (pageStart === null || start < pageStart)) {
+            pageStart = start;
         }
     });
+
+    if (pageStart) {
+        const totalElapsed = Math.round((now - pageStart) / 1000);
+        const perQuestionElapsed = totalElapsed / questionsCount;
+
+        questionsOnPage.value.forEach((q) => {
+            const index = q.number - 1;
+            questionTimes.value[index] += perQuestionElapsed;
+            questionStartTimestamps.value[index] = null;
+        });
+    }
 }
 
 function completeTest() {
     stopTimingCurrentPage();
+    finishTime.value = Date.now();
     isTestComplete.value = true;
     showTest.value = false;
 }
@@ -217,7 +232,7 @@ function confirmEnd() {
                 selected_category: opt ? opt.category : null,
                 selected_group: opt ? (opt.group ?? null) : null,
                 points: opt ? opt.points : null,
-                time_seconds: questionTimes.value[idx],
+                time_seconds: Math.round(questionTimes.value[idx]),
             };
         }),
     };
@@ -236,13 +251,17 @@ function selectAnswer(questionIndex: number, optionIndex: number) {
 
 function formatTime(sec: number | null): string {
     if (sec === null || isNaN(sec)) return '–';
-    if (sec < 60) return `${sec} Sekunden`;
-    const min = Math.round(sec / 60);
+    const roundedSec = Math.round(sec);
+    if (roundedSec < 60) return `${roundedSec} Sekunden`;
+    const min = Math.round(roundedSec / 60);
     return `${min} Minuten`;
 }
 
 const totalTimeTaken = computed(() => {
-    return isTestComplete.value ? questionTimes.value.reduce((a, b) => a + b, 0) : null;
+    if (isTestComplete.value && startTime.value && finishTime.value) {
+        return Math.round((finishTime.value - startTime.value) / 1000);
+    }
+    return null;
 });
 </script>
 


### PR DESCRIPTION
The LMT test was generating an incorrect total duration (e.g., 166m 56s) instead of the real time taken. This was due to the multi-question layout of the test (15 questions per page), where the time spent on a single page was being added to the individual duration of every question on that page. When these per-question durations were summed up for the result, the total was inflated by a factor of 15.

I fixed this by:
1. Using absolute timestamps (startTime and finishTime) to calculate the total duration of the test.
2. Distributing the time spent on each page equally among the questions on that page, so that individual question records are accurate and their sum matches the total test duration.
3. Updating the results data sent to the server to use this correctly calculated duration.

---
*PR created automatically by Jules for task [2823907002157086431](https://jules.google.com/task/2823907002157086431) started by @miqr-dev*