### PR TITLE
Fix LMT Gesamtdauer to use real elapsed test time

### DIFF
--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -92,6 +92,7 @@ const userAnswers = ref<(number | null)[]>(Array(questions.value.length).fill(nu
 const questionTimes = ref<number[]>(Array(questions.value.length).fill(0));
 const questionStartTimestamps = ref<(number | null)[]>(Array(questions.value.length).fill(null));
 const startTime = ref<number | null>(null);
+const completedAt = ref<number | null>(null);
 
 const totalPages = computed(() => Math.ceil(questions.value.length / questionsPerPage));
 
@@ -132,6 +133,7 @@ function startTest() {
     questionTimes.value = Array(questions.value.length).fill(0);
     questionStartTimestamps.value = Array(questions.value.length).fill(null);
     startTime.value = Date.now();
+    completedAt.value = null;
 
     // Start timing for visible questions
     questionsOnPage.value.forEach((q) => {
@@ -187,6 +189,7 @@ function stopTimingCurrentPage() {
 
 function completeTest() {
     stopTimingCurrentPage();
+    completedAt.value = Date.now();
     isTestComplete.value = true;
     showTest.value = false;
 }
@@ -242,7 +245,10 @@ function formatTime(sec: number | null): string {
 }
 
 const totalTimeTaken = computed(() => {
-    return isTestComplete.value ? questionTimes.value.reduce((a, b) => a + b, 0) : null;
+    if (!isTestComplete.value || startTime.value === null || completedAt.value === null) {
+        return null;
+    }
+    return Math.round((completedAt.value - startTime.value) / 1000);
 });
 </script>
 

--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -93,6 +93,8 @@ const questionTimes = ref<number[]>(Array(questions.value.length).fill(0));
 const questionStartTimestamps = ref<(number | null)[]>(Array(questions.value.length).fill(null));
 const startTime = ref<number | null>(null);
 const completedAt = ref<number | null>(null);
+const startTimePerf = ref<number | null>(null);
+const completedAtPerf = ref<number | null>(null);
 
 const totalPages = computed(() => Math.ceil(questions.value.length / questionsPerPage));
 
@@ -133,7 +135,9 @@ function startTest() {
     questionTimes.value = Array(questions.value.length).fill(0);
     questionStartTimestamps.value = Array(questions.value.length).fill(null);
     startTime.value = Date.now();
+    startTimePerf.value = performance.now();
     completedAt.value = null;
+    completedAtPerf.value = null;
 
     // Start timing for visible questions
     questionsOnPage.value.forEach((q) => {
@@ -190,6 +194,7 @@ function stopTimingCurrentPage() {
 function completeTest() {
     stopTimingCurrentPage();
     completedAt.value = Date.now();
+    completedAtPerf.value = performance.now();
     isTestComplete.value = true;
     showTest.value = false;
 }
@@ -245,7 +250,13 @@ function formatTime(sec: number | null): string {
 }
 
 const totalTimeTaken = computed(() => {
-    if (!isTestComplete.value || startTime.value === null || completedAt.value === null) {
+    if (!isTestComplete.value) {
+        return null;
+    }
+    if (startTimePerf.value !== null && completedAtPerf.value !== null) {
+        return Math.round((completedAtPerf.value - startTimePerf.value) / 1000);
+    }
+    if (startTime.value === null || completedAt.value === null) {
         return null;
     }
     return Math.round((completedAt.value - startTime.value) / 1000);


### PR DESCRIPTION
### Motivation
- The displayed `Gesamtdauer` was inflated because the code summed per-question timers, which in the multi-question page layout gave each question the full page duration.

### Description
- Compute `total_time_seconds` from a `startTime` and a new `completedAt` timestamp and return `Math.round((completedAt - startTime) / 1000)` when the test is finished.
- Initialize `completedAt` to `null` on `startTest()` and set it to `Date.now()` in `completeTest()` so the end time is frozen at completion.
- Leave per-question timing logic unchanged; the emitted `total_time_seconds` now reflects actual wall-clock elapsed time instead of the per-question aggregate.

### Testing
- Ran `npx eslint resources/js/pages/LMT.vue` and observed an existing lint issue: `isForcedFinish` is assigned but never used.
- No additional automated tests were introduced or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9febe7c088329a068aab77de172a9)