### PR TITLE
Add pause/resume state support for LMT, AVEM and 628 tests

### DIFF
--- a/resources/js/components/LiveExamStatusTable.vue
+++ b/resources/js/components/LiveExamStatusTable.vue
@@ -97,11 +97,14 @@ const getParticipantStatusFromExam = (exam: any, participant: any) => {
 const getParticipantStatus = (participant: any) =>
   getParticipantStatusFromExam(localExam.value, participant)
 
-const PAUSE_SUPPORTED_TEST_CODES = new Set(['FPI-R', 'MRT-A', 'MRT-B', 'BIT-2'])
+const PAUSE_SUPPORTED_TEST_CODES = new Set(['FPI-R', 'MRT-A', 'MRT-B', 'BIT-2', 'LMT', 'AVEM', '628', 'KONZENTRATIONSTEST'])
 
 const isCurrentStepPauseSupported = () => {
   const test = localExam.value?.current_step?.test
   const testCode = (test?.code || test?.name || '').toString().trim().toUpperCase()
+  if (testCode.startsWith('628')) {
+    return true
+  }
   return PAUSE_SUPPORTED_TEST_CODES.has(testCode)
 }
 

--- a/resources/js/pages/AVEM.vue
+++ b/resources/js/pages/AVEM.vue
@@ -6,9 +6,15 @@ import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { AVEM_QUESTIONS } from '@/pages/Questions/AVEMQuestions';
 import { Head } from '@inertiajs/vue3';
 import { Info } from 'lucide-vue-next';
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 
-const emit = defineEmits(['complete', 'started']);
+const props = defineProps<{
+    pausedTestResult?: {
+        answers: { number: number; answer: number | null }[];
+    };
+}>();
+
+const emit = defineEmits(['complete', 'started', 'update:answers']);
 
 const showTest = ref(false);
 const answers = ref<Record<number, number | null>>({});
@@ -32,6 +38,23 @@ const { isForcedFinish, clearForcedFinish } = useTeacherForceFinish({
 
 // init answers
 AVEM_QUESTIONS.forEach((q) => (answers.value[q.number] = null));
+
+if (props.pausedTestResult?.answers) {
+    props.pausedTestResult.answers.forEach((a) => {
+        answers.value[a.number] = a.answer;
+    });
+    showTest.value = true;
+}
+
+watch(
+    answers,
+    (newAnswers) => {
+        emit('update:answers', {
+            answers: AVEM_QUESTIONS.map((q) => ({ number: q.number, answer: newAnswers[q.number] })),
+        });
+    },
+    { deep: true, immediate: true },
+);
 
 const instructions = `Wir bitten Sie, einige Ihrer üblichen Verhaltensweisen, Einstellungen und Gewohnheiten zu beschreiben, wobei vor allem Ihr Arbeitsleben Bezug genommen wird. Dazu finden Sie im Folgenden eine Reihe von Aussagen. Lesen Sie jeden dieser Sätze gründlich und entscheiden Sie, in welchem Maße er auf Sie persönlich zutrifft.`;
 

--- a/resources/js/pages/Exams/ExamRoom.vue
+++ b/resources/js/pages/Exams/ExamRoom.vue
@@ -112,7 +112,7 @@ const testComponents: Record<string, unknown> = {
 };
 
 const stepStatuses = ref<Record<number, StepStatusEntry>>(normalizeStepStatuses(props.stepStatuses));
-const testsWithPauseSupport = new Set(['BIT-2', 'FPI-R', 'MRT-A', 'MRT-B']);
+const testsWithPauseSupport = new Set(['BIT-2', 'FPI-R', 'MRT-A', 'MRT-B', 'LMT', 'AVEM', '628']);
 const visibleSteps = computed(() =>
   props.exam.steps.filter((step) => {
     if (props.exam.current_step?.id === step.id) {

--- a/resources/js/pages/Konzentrationstest.vue
+++ b/resources/js/pages/Konzentrationstest.vue
@@ -6,7 +6,23 @@ import { Input } from '@/components/ui/input';
 import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { KONZ_PAGE2_SVG_ROWS } from '@/pages/Questions/konzPage2SvgRows';
 import { Head } from '@inertiajs/vue3';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
+
+const props = defineProps<{
+    pausedTestResult?: {
+        page?: number;
+        page1?: string[];
+        page2?: string[];
+        page3?: string[];
+        page4?: string[];
+        page5?: string[];
+        copy_marks?: boolean[][][];
+        page4_marks?: boolean[][];
+        page5_marks?: boolean[];
+        page5_marks2?: boolean[];
+        page5_tick_marks?: boolean[][];
+    };
+}>();
 
 const startedAtMs = Date.now();
 
@@ -103,7 +119,7 @@ const confirmFinishDespiteUnanswered = () => {
     showUnansweredDialog.value = false;
     submitResults();
 };
-const emit = defineEmits(['complete', 'started']);
+const emit = defineEmits(['complete', 'started', 'update:answers']);
 
 onMounted(() => {
     emit('started');
@@ -675,6 +691,40 @@ const rowLabel = (i: number) => String.fromCharCode(97 + i); // a..j
 // put near your other PAGE 5 helpers
 const GAP_AFTER = [5, 8, 15, 18, 21, 23]; // 1-based
 const hasGapAfter = (zeroBasedIndex: number) => GAP_AFTER.includes(zeroBasedIndex + 1);
+
+if (props.pausedTestResult) {
+    page.value = props.pausedTestResult.page ?? page.value;
+    if (props.pausedTestResult.page1) page1Inputs.value = [...props.pausedTestResult.page1];
+    if (props.pausedTestResult.page2) page2Answers.value = [...props.pausedTestResult.page2];
+    if (props.pausedTestResult.page3) copyCounts.value = [...props.pausedTestResult.page3];
+    if (props.pausedTestResult.page4) page4Answers.value = [...props.pausedTestResult.page4];
+    if (props.pausedTestResult.page5) page5TickSums.value = [...props.pausedTestResult.page5];
+    if (props.pausedTestResult.copy_marks) copyMarks.value = props.pausedTestResult.copy_marks;
+    if (props.pausedTestResult.page4_marks) page4Marks.value = props.pausedTestResult.page4_marks;
+    if (props.pausedTestResult.page5_marks) page5Marks.value = props.pausedTestResult.page5_marks;
+    if (props.pausedTestResult.page5_marks2) page5Marks2.value = props.pausedTestResult.page5_marks2;
+    if (props.pausedTestResult.page5_tick_marks) page5TickMarks.value = props.pausedTestResult.page5_tick_marks;
+}
+
+watch(
+    [page, page1Inputs, page2Answers, copyCounts, page4Answers, page5TickSums, copyMarks, page4Marks, page5Marks, page5Marks2, page5TickMarks],
+    () => {
+        emit('update:answers', {
+            page: page.value,
+            page1: page1Inputs.value,
+            page2: page2Answers.value,
+            page3: copyCounts.value,
+            page4: page4Answers.value,
+            page5: page5TickSums.value,
+            copy_marks: copyMarks.value,
+            page4_marks: page4Marks.value,
+            page5_marks: page5Marks.value,
+            page5_marks2: page5Marks2.value,
+            page5_tick_marks: page5TickMarks.value,
+        });
+    },
+    { deep: true, immediate: true },
+);
 </script>
 
 <template>

--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { Head } from '@inertiajs/vue3';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import { LMT_QUESTIONS, LMTQuestion } from '@/pages/Questions/LMTQuestions';
 
@@ -100,7 +100,14 @@ const totalPages = computed(() => Math.ceil(questions.value.length / questionsPe
 
 const isTestComplete = ref(false);
 
-const emit = defineEmits(['complete', 'started']);
+const props = defineProps<{
+    pausedTestResult?: {
+        answers: { number: number; answer: number | null }[];
+        currentPage?: number;
+    };
+}>();
+
+const emit = defineEmits(['complete', 'started', 'update:answers']);
 
 const endConfirmOpen = ref(false);
 
@@ -125,6 +132,28 @@ const questionsOnPage = computed(() => {
     const end = start + questionsPerPage;
     return questions.value.slice(start, end);
 });
+
+if (props.pausedTestResult?.answers) {
+    props.pausedTestResult.answers.forEach((a) => {
+        userAnswers.value[a.number - 1] = a.answer;
+    });
+    if (typeof props.pausedTestResult.currentPage === 'number' && props.pausedTestResult.currentPage >= 1) {
+        currentPage.value = props.pausedTestResult.currentPage;
+    }
+    showTest.value = true;
+    startTimingCurrentPage();
+}
+
+watch(
+    [userAnswers, currentPage],
+    ([newAnswers, newCurrentPage]) => {
+        emit('update:answers', {
+            answers: questions.value.map((q, idx) => ({ number: q.number, answer: newAnswers[idx] })),
+            currentPage: newCurrentPage,
+        });
+    },
+    { deep: true, immediate: true },
+);
 
 function startTest() {
     emit('started');


### PR DESCRIPTION
### Motivation
- Bring `LMT`, `AVEM` and `628` to feature parity with existing pausable tests (`FPI-R`, `BIT-2`, `MRT-*`) so participants can pause and resume these tests. 
- Persist the specific state per test as required: `LMT` must save current page and answers, `AVEM` only needs answers, and `628` must save page, all text inputs and click/mark (strikethrough) matrices. 
- Use the backend-recognized test name `628` for pause support and do not change `LMT2` support.

### Description
- Added `LMT`, `AVEM`, and `628` to the pause-support allowlist in `resources/js/pages/Exams/ExamRoom.vue` so paused payloads are forwarded into those test components. 
- `LMT.vue`: added `defineProps` for `pausedTestResult`, hydrate saved `answers` and `currentPage` on load, call `startTimingCurrentPage()` after hydration, and emit incremental pause payloads via an `update:answers` watcher containing `answers` and `currentPage`. 
- `AVEM.vue`: added `defineProps` for `pausedTestResult`, hydrate saved `answers` on load, and emit incremental pause payloads via an `update:answers` watcher containing all answers. 
- `Konzentrationstest.vue` (the `628` page): added `defineProps` for a rich `pausedTestResult` (page, `page1`..`page5` inputs, `copy_marks`, `page4_marks`, `page5_marks`, `page5_marks2`, `page5_tick_marks`), hydrate page, text inputs and all mark matrices on load, and emit incremental pause payloads via an `update:answers` watcher including page number, inputs and all mark states so marks/strikethroughs are persisted. 

### Testing
- Built the frontend with `npm run -s build` and the production build completed successfully. 
- The build emitted existing non-blocking warnings (chunk-size and an unrelated SFC warning in `Badge.vue`) but no errors preventing release.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb165a82dc8329b1fd124d0623cfc2)