### PR TITLE
Fix paused/resumed timing persistence for MRT, LMT, and 628

### DIFF
--- a/resources/js/pages/Konzentrationstest.vue
+++ b/resources/js/pages/Konzentrationstest.vue
@@ -21,10 +21,12 @@ const props = defineProps<{
         page5_marks?: boolean[];
         page5_marks2?: boolean[];
         page5_tick_marks?: boolean[][];
+        total_time_seconds?: number;
     };
 }>();
 
-const startedAtMs = Date.now();
+const elapsedSecondsBeforeResume = ref(0);
+const startedAtMs = ref(Date.now());
 
 /* =========================================================
    NAV
@@ -67,7 +69,7 @@ const buildResults = () => ({
     page5: page5TickSums.value,
     wrong_count: wrongCount.value,
     performance_category: performanceCategory.value,
-    total_time_seconds: Math.max(0, Math.round((Date.now() - startedAtMs) / 1000)),
+    total_time_seconds: getElapsedSeconds(),
 });
 
 const countEmpty = (answers: string[]) => answers.filter((a) => a.trim() === '').length;
@@ -704,6 +706,8 @@ if (props.pausedTestResult) {
     if (props.pausedTestResult.page5_marks) page5Marks.value = props.pausedTestResult.page5_marks;
     if (props.pausedTestResult.page5_marks2) page5Marks2.value = props.pausedTestResult.page5_marks2;
     if (props.pausedTestResult.page5_tick_marks) page5TickMarks.value = props.pausedTestResult.page5_tick_marks;
+    elapsedSecondsBeforeResume.value = props.pausedTestResult.total_time_seconds ?? 0;
+    startedAtMs.value = Date.now();
 }
 
 watch(
@@ -721,10 +725,15 @@ watch(
             page5_marks: page5Marks.value,
             page5_marks2: page5Marks2.value,
             page5_tick_marks: page5TickMarks.value,
+            total_time_seconds: getElapsedSeconds(),
         });
     },
     { deep: true, immediate: true },
 );
+
+function getElapsedSeconds() {
+    return elapsedSecondsBeforeResume.value + Math.max(0, Math.round((Date.now() - startedAtMs.value) / 1000));
+}
 </script>
 
 <template>

--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -92,9 +92,7 @@ const userAnswers = ref<(number | null)[]>(Array(questions.value.length).fill(nu
 const questionTimes = ref<number[]>(Array(questions.value.length).fill(0));
 const questionStartTimestamps = ref<(number | null)[]>(Array(questions.value.length).fill(null));
 const startTime = ref<number | null>(null);
-const completedAt = ref<number | null>(null);
-const startTimePerf = ref<number | null>(null);
-const completedAtPerf = ref<number | null>(null);
+const elapsedSecondsBeforeResume = ref(0);
 
 const totalPages = computed(() => Math.ceil(questions.value.length / questionsPerPage));
 
@@ -104,6 +102,7 @@ const props = defineProps<{
     pausedTestResult?: {
         answers: { number: number; answer: number | null }[];
         currentPage?: number;
+        total_time_seconds?: number;
     };
 }>();
 
@@ -140,7 +139,9 @@ if (props.pausedTestResult?.answers) {
     if (typeof props.pausedTestResult.currentPage === 'number' && props.pausedTestResult.currentPage >= 1) {
         currentPage.value = props.pausedTestResult.currentPage;
     }
+    elapsedSecondsBeforeResume.value = props.pausedTestResult.total_time_seconds ?? 0;
     showTest.value = true;
+    startTime.value = Date.now();
     startTimingCurrentPage();
 }
 
@@ -150,6 +151,7 @@ watch(
         emit('update:answers', {
             answers: questions.value.map((q, idx) => ({ number: q.number, answer: newAnswers[idx] })),
             currentPage: newCurrentPage,
+            total_time_seconds: getCurrentElapsedSeconds(),
         });
     },
     { deep: true, immediate: true },
@@ -164,9 +166,7 @@ function startTest() {
     questionTimes.value = Array(questions.value.length).fill(0);
     questionStartTimestamps.value = Array(questions.value.length).fill(null);
     startTime.value = Date.now();
-    startTimePerf.value = performance.now();
-    completedAt.value = null;
-    completedAtPerf.value = null;
+    elapsedSecondsBeforeResume.value = 0;
 
     // Start timing for visible questions
     questionsOnPage.value.forEach((q) => {
@@ -222,8 +222,6 @@ function stopTimingCurrentPage() {
 
 function completeTest() {
     stopTimingCurrentPage();
-    completedAt.value = Date.now();
-    completedAtPerf.value = performance.now();
     isTestComplete.value = true;
     showTest.value = false;
 }
@@ -282,14 +280,16 @@ const totalTimeTaken = computed(() => {
     if (!isTestComplete.value) {
         return null;
     }
-    if (startTimePerf.value !== null && completedAtPerf.value !== null) {
-        return Math.round((completedAtPerf.value - startTimePerf.value) / 1000);
-    }
-    if (startTime.value === null || completedAt.value === null) {
-        return null;
-    }
-    return Math.round((completedAt.value - startTime.value) / 1000);
+    return getCurrentElapsedSeconds();
 });
+
+function getCurrentElapsedSeconds(): number {
+    if (startTime.value === null) {
+        return elapsedSecondsBeforeResume.value;
+    }
+    const runningElapsed = Math.max(0, Math.round((Date.now() - startTime.value) / 1000));
+    return elapsedSecondsBeforeResume.value + runningElapsed;
+}
 </script>
 
 <template>

--- a/resources/js/pages/MRT-A.vue
+++ b/resources/js/pages/MRT-A.vue
@@ -78,6 +78,15 @@ const questionTimes = ref<number[]>(Array(mrtQuestions.length).fill(0));
 const questionStartTimestamps = ref<(number | null)[]>(Array(mrtQuestions.length).fill(null));
 const startTime = ref<number | null>(null);
 
+const getPersistedQuestionTimes = () => {
+    const now = Date.now();
+    return questionTimes.value.map((time, index) => {
+        const startedAt = questionStartTimestamps.value[index];
+        if (!startedAt) return time;
+        return time + Math.round((now - startedAt) / 1000);
+    });
+};
+
 if (props.pausedTestResult) {
     if (props.pausedTestResult.answers) {
         props.pausedTestResult.answers.forEach((a, i) => {
@@ -93,11 +102,12 @@ if (props.pausedTestResult) {
 
 watch(
     [userAnswers, questionTimes, currentQuestionIndex],
-    ([newUserAnswers, newQuestionTimes, newCurrentQuestionIndex]) => {
+    ([newUserAnswers, , newCurrentQuestionIndex]) => {
+        const persistedTimes = getPersistedQuestionTimes();
         const results = {
             answers: mrtQuestions.map((q, i) => ({
                 user_answer: newUserAnswers[i],
-                time_seconds: newQuestionTimes[i],
+                time_seconds: persistedTimes[i],
             })),
             currentQuestionIndex: newCurrentQuestionIndex,
         };

--- a/resources/js/pages/MRT-B.vue
+++ b/resources/js/pages/MRT-B.vue
@@ -78,6 +78,15 @@ const questionTimes = ref<number[]>(Array(mrtQuestions.length).fill(0));
 const questionStartTimestamps = ref<(number | null)[]>(Array(mrtQuestions.length).fill(null));
 const startTime = ref<number | null>(null);
 
+const getPersistedQuestionTimes = () => {
+    const now = Date.now();
+    return questionTimes.value.map((time, index) => {
+        const startedAt = questionStartTimestamps.value[index];
+        if (!startedAt) return time;
+        return time + Math.round((now - startedAt) / 1000);
+    });
+};
+
 if (props.pausedTestResult) {
     if (props.pausedTestResult.answers) {
         props.pausedTestResult.answers.forEach((a, i) => {
@@ -93,11 +102,12 @@ if (props.pausedTestResult) {
 
 watch(
     [userAnswers, questionTimes, currentQuestionIndex],
-    ([newUserAnswers, newQuestionTimes, newCurrentQuestionIndex]) => {
+    ([newUserAnswers, , newCurrentQuestionIndex]) => {
+        const persistedTimes = getPersistedQuestionTimes();
         const results = {
             answers: mrtQuestions.map((q, i) => ({
                 user_answer: newUserAnswers[i],
-                time_seconds: newQuestionTimes[i],
+                time_seconds: persistedTimes[i],
             })),
             currentQuestionIndex: newCurrentQuestionIndex,
         };


### PR DESCRIPTION
### Motivation

- Prevent loss of in-flight timing when a participant pauses a test so recorded question and total times reflect time spent before pausing.
- Correct LMT total time which previously used only session timing (and sometimes showed an incorrect fixed value or nothing after pause).
- Make the Konzentrationstest (628) accumulate elapsed time across resume cycles instead of resetting to component load time.

### Description

- MRT-A and MRT-B: added `getPersistedQuestionTimes()` and use its values in the `update:answers` autosave watcher so the currently-open question's elapsed seconds are included when emitting `update:answers` (files: `resources/js/pages/MRT-A.vue`, `resources/js/pages/MRT-B.vue`).
- LMT: replaced one-shot perf timing with an accumulated model using `elapsedSecondsBeforeResume` + `startTime`, persist `total_time_seconds` in the `update:answers` payload, restore it on resume, and compute total time via `getCurrentElapsedSeconds()` (file: `resources/js/pages/LMT.vue`).
- Konzentrationstest (628): introduced `elapsedSecondsBeforeResume` and `startedAtMs` refs, persist/restore `total_time_seconds`, and emit `total_time_seconds` from the autosave watcher while computing elapsed via `getElapsedSeconds()` used for final results (file: `resources/js/pages/Konzentrationstest.vue`).
- Updated autosave/watchers to include `total_time_seconds` where appropriate and adjusted watchers' parameter lists to avoid unused-variable warnings.

### Testing

- Ran `npm run -s lint`, which executed successfully but reported existing repository-wide lint errors not introduced by these changes; no unit tests were added or run for this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb69c884483299bd3c2f722062fba)