### PR TITLE
Fix Test Timing Persistence and LMT Duration Bug

### DIFF
--- a/resources/js/pages/AVEM.vue
+++ b/resources/js/pages/AVEM.vue
@@ -6,11 +6,12 @@ import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { AVEM_QUESTIONS } from '@/pages/Questions/AVEMQuestions';
 import { Head } from '@inertiajs/vue3';
 import { Info } from 'lucide-vue-next';
-import { ref, watch } from 'vue';
+import { onMounted, onUnmounted, ref, watch } from 'vue';
 
 const props = defineProps<{
     pausedTestResult?: {
         answers: { number: number; answer: number | null }[];
+        total_time_accumulated?: number;
     };
 }>();
 
@@ -18,6 +19,8 @@ const emit = defineEmits(['complete', 'started', 'update:answers']);
 
 const showTest = ref(false);
 const answers = ref<Record<number, number | null>>({});
+const startTime = ref<number | null>(null);
+const totalTimeAccumulated = ref(0);
 const endConfirmOpen = ref(false);
 
 const { isForcedFinish, clearForcedFinish } = useTeacherForceFinish({
@@ -43,18 +46,41 @@ if (props.pausedTestResult?.answers) {
     props.pausedTestResult.answers.forEach((a) => {
         answers.value[a.number] = a.answer;
     });
+    const accumulated = props.pausedTestResult.total_time_seconds ?? props.pausedTestResult.total_time_accumulated;
+    if (typeof accumulated === 'number') {
+        totalTimeAccumulated.value = accumulated;
+    }
     showTest.value = true;
+    startTime.value = Date.now();
 }
+
+const getEmittedResults = () => {
+    const currentSessionTime = startTime.value ? Math.round((Date.now() - startTime.value) / 1000) : 0;
+    return {
+        answers: AVEM_QUESTIONS.map((q) => ({ number: q.number, answer: answers.value[q.number] })),
+        total_time_seconds: totalTimeAccumulated.value + currentSessionTime,
+    };
+};
 
 watch(
     answers,
-    (newAnswers) => {
-        emit('update:answers', {
-            answers: AVEM_QUESTIONS.map((q) => ({ number: q.number, answer: newAnswers[q.number] })),
-        });
+    () => {
+        emit('update:answers', getEmittedResults());
     },
     { deep: true, immediate: true },
 );
+
+let timer: any;
+onMounted(() => {
+    timer = setInterval(() => {
+        if (showTest.value && endConfirmOpen.value === false) {
+            emit('update:answers', getEmittedResults());
+        }
+    }, 5000);
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+});
 
 const instructions = `Wir bitten Sie, einige Ihrer üblichen Verhaltensweisen, Einstellungen und Gewohnheiten zu beschreiben, wobei vor allem Ihr Arbeitsleben Bezug genommen wird. Dazu finden Sie im Folgenden eine Reihe von Aussagen. Lesen Sie jeden dieser Sätze gründlich und entscheiden Sie, in welchem Maße er auf Sie persönlich zutrifft.`;
 
@@ -82,6 +108,7 @@ const LEGEND_TOP = [
 
 function startTest() {
     emit('started');
+    startTime.value = Date.now();
     showTest.value = true;
 }
 function finishTest() {
@@ -96,8 +123,10 @@ function cancelEnd() {
 function confirmEnd() {
     clearForcedFinish(false);
     endConfirmOpen.value = false;
+    const currentSessionTime = startTime.value ? Math.round((Date.now() - startTime.value) / 1000) : 0;
     const results = {
         answers: AVEM_QUESTIONS.map((q) => ({ number: q.number, answer: answers.value[q.number] })),
+        total_time_seconds: totalTimeAccumulated.value + currentSessionTime,
     };
     emit('complete', results);
 }

--- a/resources/js/pages/BIT-2.vue
+++ b/resources/js/pages/BIT-2.vue
@@ -4,12 +4,13 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { BIT2_QUESTIONS } from '@/pages/Questions/BIT2Questions';
 import { Head } from '@inertiajs/vue3';
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 const props = defineProps<{
     pausedTestResult?: {
         answers: { number: number; answer: number | null }[];
         pageIndex?: number;
+        total_time_accumulated?: number;
     };
     timeRemainingSeconds?: number | null;
 }>();
@@ -19,6 +20,8 @@ const emit = defineEmits(['complete', 'update:answers', 'started']);
 const showTest = ref(false);
 const pageIndex = ref(0); // 0 first 27, 1 remaining
 const answers = ref<Record<number, number | null>>({});
+const startTime = ref<number | null>(null);
+const totalTimeAccumulated = ref(0);
 const endConfirmOpen = ref(false);
 
 const { isForcedFinish, clearForcedFinish } = useTeacherForceFinish({
@@ -48,23 +51,45 @@ if (props.pausedTestResult) {
     if (props.pausedTestResult.pageIndex) {
         pageIndex.value = props.pausedTestResult.pageIndex;
     }
+    const accumulated = props.pausedTestResult.total_time_seconds ?? props.pausedTestResult.total_time_accumulated;
+    if (typeof accumulated === 'number') {
+        totalTimeAccumulated.value = accumulated;
+    }
     showTest.value = true;
+    startTime.value = Date.now();
 }
+
+const getEmittedResults = () => {
+    const currentSessionTime = startTime.value ? Math.round((Date.now() - startTime.value) / 1000) : 0;
+    return {
+        answers: BIT2_QUESTIONS.map((q) => ({
+            number: q.number,
+            answer: answers.value[q.number],
+        })),
+        pageIndex: pageIndex.value,
+        total_time_seconds: totalTimeAccumulated.value + currentSessionTime,
+    };
+};
 
 watch(
     [answers, pageIndex],
-    ([newAnswers, newPageIndex]) => {
-        const results = {
-            answers: BIT2_QUESTIONS.map((q) => ({
-                number: q.number,
-                answer: newAnswers[q.number],
-            })),
-            pageIndex: newPageIndex,
-        };
-        emit('update:answers', results);
+    () => {
+        emit('update:answers', getEmittedResults());
     },
     { deep: true, immediate: true },
 );
+
+let timer: any;
+onMounted(() => {
+    timer = setInterval(() => {
+        if (showTest.value && endConfirmOpen.value === false) {
+            emit('update:answers', getEmittedResults());
+        }
+    }, 5000);
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+});
 
 const firstPageQuestions = computed(() => BIT2_QUESTIONS.slice(0, 27));
 const secondPageLeft = computed(() => BIT2_QUESTIONS.slice(27, 54));
@@ -72,6 +97,7 @@ const secondPageRight = computed(() => BIT2_QUESTIONS.slice(54));
 
 function startTest() {
     emit('started');
+    startTime.value = Date.now();
     showTest.value = true;
     pageIndex.value = 0;
 }
@@ -93,8 +119,10 @@ function cancelEnd() {
 function confirmEnd() {
     clearForcedFinish(false);
     endConfirmOpen.value = false;
+    const currentSessionTime = startTime.value ? Math.round((Date.now() - startTime.value) / 1000) : 0;
     const results = {
         answers: BIT2_QUESTIONS.map((q) => ({ number: q.number, answer: answers.value[q.number] })),
+        total_time_seconds: totalTimeAccumulated.value + currentSessionTime,
     };
     emit('complete', results);
 }

--- a/resources/js/pages/FPI-R.vue
+++ b/resources/js/pages/FPI-R.vue
@@ -4,7 +4,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { FPI_QUESTIONS } from '@/pages/Questions/FPIQuestions';
 import { Head } from '@inertiajs/vue3';
-import { computed, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 
 import { watch } from 'vue';
 
@@ -12,6 +12,7 @@ const props = defineProps<{
     pausedTestResult?: {
         answers: { number: number; answer: 'stimmt' | 'stimmtNicht' | null }[];
         blockIndex?: number;
+        total_time_accumulated?: number;
     };
     timeRemainingSeconds?: number | null;
 }>();
@@ -45,6 +46,7 @@ const { isForcedFinish, clearForcedFinish } = useTeacherForceFinish({
     },
 });
 const startTime = ref<number | null>(null);
+const totalTimeAccumulated = ref(0);
 const totalQuestions = FPI_QUESTIONS.length;
 const currentFrom = computed(() => blockIndex.value * QUESTIONS_PER_BLOCK + 1);
 const currentTo = computed(() => Math.min((blockIndex.value + 1) * QUESTIONS_PER_BLOCK, totalQuestions));
@@ -64,23 +66,44 @@ if (props.pausedTestResult) {
     if (props.pausedTestResult.blockIndex) {
         blockIndex.value = props.pausedTestResult.blockIndex;
     }
+    if (typeof props.pausedTestResult.total_time_accumulated === 'number') {
+        totalTimeAccumulated.value = props.pausedTestResult.total_time_accumulated;
+    }
     showTest.value = true;
+    startTime.value = Date.now();
 }
+
+const getEmittedResults = () => {
+    const currentSessionTime = startTime.value ? Math.round((Date.now() - startTime.value) / 1000) : 0;
+    return {
+        answers: FPI_QUESTIONS.map((q) => ({
+            number: q.number,
+            answer: answers.value[q.number],
+        })),
+        blockIndex: blockIndex.value,
+        total_time_accumulated: totalTimeAccumulated.value + currentSessionTime,
+    };
+};
 
 watch(
     [answers, blockIndex],
-    ([newAnswers, newBlockIndex]) => {
-        const results = {
-            answers: FPI_QUESTIONS.map((q) => ({
-                number: q.number,
-                answer: newAnswers[q.number],
-            })),
-            blockIndex: newBlockIndex,
-        };
-        emit('update:answers', results);
+    () => {
+        emit('update:answers', getEmittedResults());
     },
     { deep: true, immediate: true },
 );
+
+let timer: any;
+onMounted(() => {
+    timer = setInterval(() => {
+        if (showTest.value && !finished.value) {
+            emit('update:answers', getEmittedResults());
+        }
+    }, 5000);
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+});
 
 // Compute block questions
 const totalBlocks = computed(() => Math.ceil(FPI_QUESTIONS.length / QUESTIONS_PER_BLOCK));
@@ -144,7 +167,8 @@ function confirmEnd() {
     });
     endConfirmOpen.value = false;
     finished.value = true;
-    const totalTimeSeconds = startTime.value ? Math.round((Date.now() - startTime.value) / 1000) : null;
+    const currentSessionTime = startTime.value ? Math.round((Date.now() - startTime.value) / 1000) : 0;
+    const totalTimeSeconds = totalTimeAccumulated.value + currentSessionTime;
     const results = {
         answers: FPI_QUESTIONS.map((q) => ({
             number: q.number,

--- a/resources/js/pages/Konzentrationstest.vue
+++ b/resources/js/pages/Konzentrationstest.vue
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { KONZ_PAGE2_SVG_ROWS } from '@/pages/Questions/konzPage2SvgRows';
 import { Head } from '@inertiajs/vue3';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 const props = defineProps<{
     pausedTestResult?: {
@@ -21,10 +21,12 @@ const props = defineProps<{
         page5_marks?: boolean[];
         page5_marks2?: boolean[];
         page5_tick_marks?: boolean[][];
+        total_time_seconds?: number;
     };
 }>();
 
-const startedAtMs = Date.now();
+const startedAtMs = ref(Date.now());
+const accumulatedTimeSeconds = ref(0);
 
 /* =========================================================
    NAV
@@ -67,7 +69,7 @@ const buildResults = () => ({
     page5: page5TickSums.value,
     wrong_count: wrongCount.value,
     performance_category: performanceCategory.value,
-    total_time_seconds: Math.max(0, Math.round((Date.now() - startedAtMs) / 1000)),
+    total_time_seconds: accumulatedTimeSeconds.value + Math.max(0, Math.round((Date.now() - startedAtMs.value) / 1000)),
 });
 
 const countEmpty = (answers: string[]) => answers.filter((a) => a.trim() === '').length;
@@ -121,8 +123,17 @@ const confirmFinishDespiteUnanswered = () => {
 };
 const emit = defineEmits(['complete', 'started', 'update:answers']);
 
+let timer: any;
 onMounted(() => {
     emit('started');
+    timer = setInterval(() => {
+        if (!hasCompleted.value) {
+            emit('update:answers', buildResults());
+        }
+    }, 5000);
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
 });
 
 const toggleMark = (marks: boolean[], i: number) => (marks[i] = !marks[i]);
@@ -704,6 +715,9 @@ if (props.pausedTestResult) {
     if (props.pausedTestResult.page5_marks) page5Marks.value = props.pausedTestResult.page5_marks;
     if (props.pausedTestResult.page5_marks2) page5Marks2.value = props.pausedTestResult.page5_marks2;
     if (props.pausedTestResult.page5_tick_marks) page5TickMarks.value = props.pausedTestResult.page5_tick_marks;
+    if (typeof props.pausedTestResult.total_time_seconds === 'number') {
+        accumulatedTimeSeconds.value = props.pausedTestResult.total_time_seconds;
+    }
 }
 
 watch(

--- a/resources/js/pages/LMT.vue
+++ b/resources/js/pages/LMT.vue
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { Head } from '@inertiajs/vue3';
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 import { LMT_QUESTIONS, LMTQuestion } from '@/pages/Questions/LMTQuestions';
 
@@ -95,6 +95,7 @@ const startTime = ref<number | null>(null);
 const completedAt = ref<number | null>(null);
 const startTimePerf = ref<number | null>(null);
 const completedAtPerf = ref<number | null>(null);
+const totalTimeAccumulated = ref(0);
 
 const totalPages = computed(() => Math.ceil(questions.value.length / questionsPerPage));
 
@@ -104,6 +105,7 @@ const props = defineProps<{
     pausedTestResult?: {
         answers: { number: number; answer: number | null }[];
         currentPage?: number;
+        total_time_accumulated?: number;
     };
 }>();
 
@@ -136,24 +138,62 @@ const questionsOnPage = computed(() => {
 if (props.pausedTestResult?.answers) {
     props.pausedTestResult.answers.forEach((a) => {
         userAnswers.value[a.number - 1] = a.answer;
+        if (typeof a.time_seconds === 'number') {
+            questionTimes.value[a.number - 1] = a.time_seconds;
+        }
     });
     if (typeof props.pausedTestResult.currentPage === 'number' && props.pausedTestResult.currentPage >= 1) {
         currentPage.value = props.pausedTestResult.currentPage;
     }
+    const accumulated = props.pausedTestResult.total_time_seconds ?? props.pausedTestResult.total_time_accumulated;
+    if (typeof accumulated === 'number') {
+        totalTimeAccumulated.value = accumulated;
+    }
     showTest.value = true;
+    startTimePerf.value = performance.now();
     startTimingCurrentPage();
 }
 
+const getEmittedResults = () => {
+    const nowPerf = performance.now();
+    const currentSessionTime = startTimePerf.value !== null ? Math.round((nowPerf - startTimePerf.value) / 1000) : 0;
+    return {
+        answers: questions.value.map((q, idx) => {
+            let ts = questionTimes.value[idx];
+            const start = questionStartTimestamps.value[idx];
+            if (start !== null) {
+                ts += Math.round((Date.now() - start) / 1000);
+            }
+            return {
+                number: q.number,
+                answer: userAnswers.value[idx],
+                time_seconds: ts,
+            };
+        }),
+        currentPage: currentPage.value,
+        total_time_seconds: totalTimeAccumulated.value + currentSessionTime,
+    };
+};
+
 watch(
     [userAnswers, currentPage],
-    ([newAnswers, newCurrentPage]) => {
-        emit('update:answers', {
-            answers: questions.value.map((q, idx) => ({ number: q.number, answer: newAnswers[idx] })),
-            currentPage: newCurrentPage,
-        });
+    () => {
+        emit('update:answers', getEmittedResults());
     },
     { deep: true, immediate: true },
 );
+
+let timer: any;
+onMounted(() => {
+    timer = setInterval(() => {
+        if (showTest.value && !isTestComplete.value) {
+            emit('update:answers', getEmittedResults());
+        }
+    }, 5000);
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+});
 
 function startTest() {
     emit('started');
@@ -282,13 +322,15 @@ const totalTimeTaken = computed(() => {
     if (!isTestComplete.value) {
         return null;
     }
+    let currentSessionSeconds = 0;
     if (startTimePerf.value !== null && completedAtPerf.value !== null) {
-        return Math.round((completedAtPerf.value - startTimePerf.value) / 1000);
+        currentSessionSeconds = Math.round((completedAtPerf.value - startTimePerf.value) / 1000);
+    } else if (startTime.value !== null && completedAt.value !== null) {
+        currentSessionSeconds = Math.round((completedAt.value - startTime.value) / 1000);
+    } else {
+        return totalTimeAccumulated.value;
     }
-    if (startTime.value === null || completedAt.value === null) {
-        return null;
-    }
-    return Math.round((completedAt.value - startTime.value) / 1000);
+    return totalTimeAccumulated.value + currentSessionSeconds;
 });
 </script>
 

--- a/resources/js/pages/MRT-A.vue
+++ b/resources/js/pages/MRT-A.vue
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { useMrtA } from '@/composables/useMrtA';
 import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { Head, usePage } from '@inertiajs/vue3';
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 const { mrtQuestions, calculateScores } = useMrtA();
 
@@ -85,26 +85,52 @@ if (props.pausedTestResult) {
             questionTimes.value[i] = a.time_seconds;
         });
     }
-    if (props.pausedTestResult.currentQuestionIndex) {
+    if (typeof props.pausedTestResult.currentQuestionIndex === 'number') {
         currentQuestionIndex.value = props.pausedTestResult.currentQuestionIndex;
     }
     showTest.value = true;
+    if (typeof currentQuestionIndex.value === 'number') {
+        questionStartTimestamps.value[currentQuestionIndex.value] = Date.now();
+    }
 }
+
+const getEmittedResults = () => {
+    const answers = mrtQuestions.map((q, i) => {
+        let ts = questionTimes.value[i];
+        if (i === currentQuestionIndex.value && questionStartTimestamps.value[i]) {
+            ts += Math.round((Date.now() - (questionStartTimestamps.value[i] as number)) / 1000);
+        }
+        return {
+            user_answer: userAnswers.value[i],
+            time_seconds: ts,
+        };
+    });
+    return {
+        answers,
+        currentQuestionIndex: currentQuestionIndex.value,
+        total_time_seconds: answers.reduce((acc, a) => acc + (a.time_seconds || 0), 0),
+    };
+};
 
 watch(
     [userAnswers, questionTimes, currentQuestionIndex],
-    ([newUserAnswers, newQuestionTimes, newCurrentQuestionIndex]) => {
-        const results = {
-            answers: mrtQuestions.map((q, i) => ({
-                user_answer: newUserAnswers[i],
-                time_seconds: newQuestionTimes[i],
-            })),
-            currentQuestionIndex: newCurrentQuestionIndex,
-        };
-        emit('update:answers', results);
+    () => {
+        emit('update:answers', getEmittedResults());
     },
     { deep: true, immediate: true },
 );
+
+let timer: any;
+onMounted(() => {
+    timer = setInterval(() => {
+        if (showTest.value && !isTestComplete.value) {
+            emit('update:answers', getEmittedResults());
+        }
+    }, 5000);
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+});
 
 const isTestComplete = computed(() => currentQuestionIndex.value >= mrtQuestions.length);
 

--- a/resources/js/pages/MRT-B.vue
+++ b/resources/js/pages/MRT-B.vue
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { useMrtB } from '@/composables/useMrtB';
 import { useTeacherForceFinish } from '@/composables/useTeacherForceFinish';
 import { Head, usePage } from '@inertiajs/vue3';
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 const { mrtQuestions, calculateScores } = useMrtB();
 
@@ -85,26 +85,52 @@ if (props.pausedTestResult) {
             questionTimes.value[i] = a.time_seconds;
         });
     }
-    if (props.pausedTestResult.currentQuestionIndex) {
+    if (typeof props.pausedTestResult.currentQuestionIndex === 'number') {
         currentQuestionIndex.value = props.pausedTestResult.currentQuestionIndex;
     }
     showTest.value = true;
+    if (typeof currentQuestionIndex.value === 'number') {
+        questionStartTimestamps.value[currentQuestionIndex.value] = Date.now();
+    }
 }
+
+const getEmittedResults = () => {
+    const answers = mrtQuestions.map((q, i) => {
+        let ts = questionTimes.value[i];
+        if (i === currentQuestionIndex.value && questionStartTimestamps.value[i]) {
+            ts += Math.round((Date.now() - (questionStartTimestamps.value[i] as number)) / 1000);
+        }
+        return {
+            user_answer: userAnswers.value[i],
+            time_seconds: ts,
+        };
+    });
+    return {
+        answers,
+        currentQuestionIndex: currentQuestionIndex.value,
+        total_time_seconds: answers.reduce((acc, a) => acc + (a.time_seconds || 0), 0),
+    };
+};
 
 watch(
     [userAnswers, questionTimes, currentQuestionIndex],
-    ([newUserAnswers, newQuestionTimes, newCurrentQuestionIndex]) => {
-        const results = {
-            answers: mrtQuestions.map((q, i) => ({
-                user_answer: newUserAnswers[i],
-                time_seconds: newQuestionTimes[i],
-            })),
-            currentQuestionIndex: newCurrentQuestionIndex,
-        };
-        emit('update:answers', results);
+    () => {
+        emit('update:answers', getEmittedResults());
     },
     { deep: true, immediate: true },
 );
+
+let timer: any;
+onMounted(() => {
+    timer = setInterval(() => {
+        if (showTest.value && !isTestComplete.value) {
+            emit('update:answers', getEmittedResults());
+        }
+    }, 5000);
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+});
 
 const isTestComplete = computed(() => currentQuestionIndex.value >= mrtQuestions.length);
 


### PR DESCRIPTION
Fixed a critical issue where test timing was lost or incorrectly calculated when tests were paused and resumed. 

Changes include:
1.  **MRT-A/B**: Improved timing by adding a periodic 5-second sync that includes the current question's elapsed time. Correctly re-initialize start timestamps upon resuming from a paused state.
2.  **LMT**: Resolved bugs where LMT timing showed incorrect values (e.g., 3 minutes) or disappeared entirely after a pause. The test now restores previous session data and correctly accumulates total duration.
3.  **Konzentrationstest (628)**: Updated to track accumulated time across pauses instead of resetting on component reload.
4.  **FPI-R, AVEM, BIT-2**: Standardized timing persistence logic for all tests that support the pause function to ensure consistent behavior across the application.

All timing data is now periodically synced with the server to minimize data loss if a browser tab is closed or a test is remotely paused by a teacher.

---
*PR created automatically by Jules for task [2319861239929420916](https://jules.google.com/task/2319861239929420916) started by @miqr-dev*